### PR TITLE
Adding archiveAfterDestroy option

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -51,4 +51,6 @@ For yarn please run:
   
   **-r --revision** - You git revision, can be a branch tag or a commit hash. Default value `master`
 
+  **--archiveAfterDestroy** - Archive the environment after a successful destroy
+
   **-h --help** - Get help

--- a/node/api-client.js
+++ b/node/api-client.js
@@ -1,6 +1,6 @@
 const axios = require('axios');
 
-const apiBaseUrl = 'https://api.env0.com';
+const apiBaseUrl = process.env.ENV0_API_URL || 'https://api.env0.com';
 
 class Env0ApiClient {
   async init(apiKey, apiSecret) {

--- a/node/env0-deploy-cli.js
+++ b/node/env0-deploy-cli.js
@@ -12,6 +12,7 @@ const optionDefinitions = [
   { name: 'environmentName', alias: 'e', type: String, description: 'The environment name you would like to create, if it exists it will deploy to that environment' },
   { name: 'environmentVariables', alias: 'v', type: String, multiple: true, defaultValue: [], description: 'The environment variables to set on the deployed environment - works only on deploy and can be multiple, the format is \"environmentVariableName1=value\"' },
   { name: 'revision', alias: 'r', type: String, defaultValue: 'master', description: 'Your git revision, can be a branch tag or a commit hash. Default value \"master\" ' },
+  { name: 'archiveAfterDestroy',  type: Boolean, defaultValue: false, description: 'Archive the environment after a successful destroy' },
   { name: 'help', alias: 'h', type: Boolean, defaultValue: false, description: 'Get help' }
 ];
 
@@ -47,8 +48,9 @@ const sections = [{
 ];
 
 optionDefinitions.forEach((option) => {
+  const alias = option.alias ? `-${option.alias}` : '';
   sections.push({
-    content: `{bold -${option.alias} --${option.name}} - {italic ${option.description}}`
+    content: `{bold ${alias} --${option.name}} - {italic ${option.description}}`
   })
 });
 

--- a/node/env0-deploy-flow.js
+++ b/node/env0-deploy-flow.js
@@ -36,6 +36,10 @@ const destroy = async (options) => {
     await deployUtils.pollEnvironmentStatus(environment.id);
     await deployUtils.destroyEnvironment(environment);
     await deployUtils.pollEnvironmentStatus(environment.id);
+    
+    if (options.archiveAfterDestroy) {
+      await deployUtils.archiveIfInactive(environment.id);
+    }
   }
   else {
     throw new Error(`Could not find an environment with the name ${options.environmentName}`);

--- a/node/env0-deploy-utils.js
+++ b/node/env0-deploy-utils.js
@@ -84,5 +84,13 @@ class DeployUtils {
     }
     console.log(`poll environment done, retryCount: ${retryCount}`);
   }
+
+  async archiveIfInactive(environmentId) {
+    const envRoute = `environments/${environmentId}`;
+    const environment = await apiClient.callApi('get', envRoute);
+    if (environment.status !== 'INACTIVE') throw new Error('Environment did not reach INACTIVE status');
+    await apiClient.callApi('put', envRoute, { data: { isArchived: true }});
+    console.log(`Environment ${environment.name} has been archived`);
+  }
 }
 module.exports = DeployUtils;


### PR DESCRIPTION
Adding `archiveAfterDestroy` option to CLI, so when we destroy our PR environments we can also archive them (after the destroy completes successfully)