### PR TITLE
Fix: Use projectId instead of organizationId to find environments

### DIFF
--- a/node/env0-deploy-flow.js
+++ b/node/env0-deploy-flow.js
@@ -17,7 +17,7 @@ const runDeployment = async (options, environmentVariables) => {
 const createAndDeploy = async (options, environmentVariables) => {
   console.log('Starting deployment');
 
-  let environment = await deployUtils.getEnvironment(options.environmentName, options.organizationId);
+  let environment = await deployUtils.getEnvironment(options.environmentName, options.projectId);
   if (!environment) {
     console.log('did not find an environment');
     environment = await deployUtils.createEnvironment(options.environmentName, options.organizationId, options.projectId);
@@ -30,7 +30,7 @@ const createAndDeploy = async (options, environmentVariables) => {
 
 const destroy = async (options) => {
   console.log('Starting destroying an environment');
-  const environment = await deployUtils.getEnvironment(options.environmentName, options.organizationId);
+  const environment = await deployUtils.getEnvironment(options.environmentName, options.projectId);
 
   if (environment) {
     await deployUtils.pollEnvironmentStatus(environment.id);

--- a/node/env0-deploy-utils.js
+++ b/node/env0-deploy-utils.js
@@ -7,9 +7,9 @@ class DeployUtils {
     await apiClient.init(options.apiKey, options.apiSecret);
   }
 
-  async getEnvironment(environmentName, organizationId) {
-    console.log(`getting all environments organizationId: ${organizationId}`);
-    const environments = await apiClient.callApi('get', `environments?organization=${organizationId}`);
+  async getEnvironment(environmentName, projectId) {
+    console.log(`getting all environments organizationId: ${projectId}`);
+    const environments = await apiClient.callApi('get', `environments?organization=${projectId}`);
     const environment = environments.find(env => env.name === environmentName);
     console.log(`returning this environment: ${JSON.stringify(environment)}`);
     return environment;

--- a/node/env0-deploy-utils.js
+++ b/node/env0-deploy-utils.js
@@ -8,8 +8,8 @@ class DeployUtils {
   }
 
   async getEnvironment(environmentName, projectId) {
-    console.log(`getting all environments organizationId: ${projectId}`);
-    const environments = await apiClient.callApi('get', `environments?organization=${projectId}`);
+    console.log(`getting all environments projectId: ${projectId}`);
+    const environments = await apiClient.callApi('get', `environments?projectId=${projectId}`);
     const environment = environments.find(env => env.name === environmentName);
     console.log(`returning this environment: ${JSON.stringify(environment)}`);
     return environment;


### PR DESCRIPTION
API has changed since projects, and `projectId` is required to find all environments