### PR TITLE
Fix - Fail when using empty string env vars 

### DIFF
--- a/node/env0-deploy-cli.js
+++ b/node/env0-deploy-cli.js
@@ -78,16 +78,9 @@ const getEnvironmentVariablesOptions = (environmentVariables) => {
   if (environmentVariables && environmentVariables.length > 0) {
     console.log('getting Environment Variables from options:', environmentVariables);
     environmentVariables.forEach(config => {
-      const configArray = config.split('=');
-      if (configArray.length === 2) {
-        result.push({
-          name: configArray[0],
-          value: configArray[1]
-        })
-      }
-      else {
-        throw new Error(`environmentVariables options are invalid`);
-      }
+      let [name, ...value] = config.split('=');
+      value = value.join("=");
+      result.push({ name, value });
     });
   }
   return result;

--- a/node/env0-deploy-cli.js
+++ b/node/env0-deploy-cli.js
@@ -78,8 +78,8 @@ const getEnvironmentVariablesOptions = (environmentVariables) => {
   if (environmentVariables && environmentVariables.length > 0) {
     console.log('getting Environment Variables from options:', environmentVariables);
     environmentVariables.forEach(config => {
-      const configArray = config.split(/=(.+)/);
-      if (configArray.length === 3) {
+      const configArray = config.split('=');
+      if (configArray.length === 2) {
         result.push({
           name: configArray[0],
           value: configArray[1]


### PR DESCRIPTION
Passing an environment variable with empty string such as `FOO=` causes the CLI to fail on validation.  
This PR fixes that.  
