### PR TITLE
Feat: add sensitive variables support

### DIFF
--- a/node/env0-deploy-flow.js
+++ b/node/env0-deploy-flow.js
@@ -53,7 +53,7 @@ const setConfigurationFromOptions = async (environmentVariables, environment, bl
   if (environmentVariables && environmentVariables.length > 0) {
     for (const config of environmentVariables) {
       console.log(`Setting Environment Variable ${config.name} to be ${config.value} in environmentId: ${environment.id}`);
-      await deployUtils.setConfiguration(environment, blueprintId, config.name, config.value);
+      await deployUtils.setConfiguration(environment, blueprintId, config.name, config.value, config.sensitive);
     }
   }
 };

--- a/node/env0-deploy-utils.js
+++ b/node/env0-deploy-utils.js
@@ -28,9 +28,9 @@ class DeployUtils {
     return environment;
   }
 
-  async setConfiguration(environment, blueprintId, configurationName, configurationValue) {
+  async setConfiguration(environment, blueprintId, configurationName, configurationValue, isSensitive) {
     const configuration = {
-      isSensitive: false,
+      isSensitive,
       name: configurationName,
       organizationId: environment.organizationId,
       scope: "ENVIRONMENT",

--- a/node/tests/env0-deploy-cli.spec.js
+++ b/node/tests/env0-deploy-cli.spec.js
@@ -1,0 +1,33 @@
+const mockOptions = {
+    help: false,
+    blue: 'pill',
+    red: 'pill',
+    environmentVariables: [ "key1=value1", "key2=value2" ],
+    sensitiveEnvironmentVariables: [ "sensitiveKey1=sensitiveValue1", "sensitiveKey2=sensitiveValue2" ]
+}
+
+jest.mock('../env0-deploy-flow');
+jest.mock('command-line-usage');
+jest.doMock('command-line-args', () => () => mockOptions);
+
+const runDeployment = require('../env0-deploy-flow');
+const run = require('../env0-deploy-cli');
+
+describe("env0-deploy-cli", () => {
+    beforeEach(() => {
+
+    })
+    it('should call run deployment with proper environment variables', async () => {
+        await run();
+
+        const expected = [
+            { name: 'key1', value: 'value1', sensitive: false},
+            { name: 'key2', value: 'value2', sensitive: false},
+            { name: 'sensitiveKey1', value: 'sensitiveValue1', sensitive: true},
+            { name: 'sensitiveKey2', value: 'sensitiveValue2', sensitive: true},
+
+        ]
+
+        expect(runDeployment).toBeCalledWith(mockOptions, expect.arrayContaining(expected));
+    })
+});

--- a/node/tests/env0-deploy-utils.spec.js
+++ b/node/tests/env0-deploy-utils.spec.js
@@ -4,7 +4,13 @@ const Env0ApiClient = require("../api-client");
 jest.mock("../api-client");
 
 describe("env0-deploy-utils", () => {
+  let callApiMock;
   const deployUtils = new DeployUtils();
+
+  beforeEach(() => {
+    callApiMock = Env0ApiClient.mock.instances[0].callApi;
+    callApiMock.mockResolvedValue([]);
+  })
 
   describe("pollEnvironmentStatus", () => {
     it("should return last environment status", async () => {
@@ -17,14 +23,12 @@ describe("env0-deploy-utils", () => {
 
   describe('Setting Configuration', () => {
     it('should query existing configurations for update', async () => {
-      const callApiMock = Env0ApiClient.mock.instances[0].callApi;
-      callApiMock.mockResolvedValue([]);
-
       await deployUtils.setConfiguration(
           {id:'environment-1', organizationId: 'organization-1'},
           'blueprint-1',
           'variable-name',
-          'variable-value'
+          'variable-value',
+          false
       );
 
       expect(callApiMock).toHaveBeenCalledWith(
@@ -35,14 +39,12 @@ describe("env0-deploy-utils", () => {
     });
 
     it('should post configuration property without id when new', async () => {
-      const callApiMock = Env0ApiClient.mock.instances[0].callApi;
-      callApiMock.mockResolvedValue([]);
-
       await deployUtils.setConfiguration(
           {id:'environment-1', organizationId: 'organization-1'},
           'blueprint-1',
           'variable-name',
-          'variable-value'
+          'variable-value',
+          false
       );
 
       expect(callApiMock).toHaveBeenCalledWith(
@@ -62,5 +64,25 @@ describe("env0-deploy-utils", () => {
           }
       );
     });
+
+    it.each`
+    isSensitive
+    ${true}
+    ${false}
+    `('should post configuration property with isSensitive: $isSensitive', async ({ isSensitive }) => {
+      await deployUtils.setConfiguration(
+          {id:'environment-1', organizationId: 'organization-1'},
+          'blueprint-1',
+          'variable-name',
+          'variable-value',
+          isSensitive
+      );
+
+      expect(callApiMock).toHaveBeenCalledWith(
+          'post',
+          'configuration',
+          { data: expect.objectContaining({ isSensitive } ) }
+      );
+    })
   });
 });

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -2472,7 +2472,7 @@ minimist@0.0.8:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
-minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
+minimist@^1.1.1, minimist@^1.2.0:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==


### PR DESCRIPTION
### Feature Request
Currently all environment variables sent to CLI get `isSensitive: false` AKA we don't support sensitive environment variables in deployment

### Solution
Besides the existing `-v` option for environment variables, I've added the `-vs` option that resembles that the passed key value variable should be marked as a sensitive environment variable.