### PR TITLE
Fix: sensitive environment variables alias

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -48,7 +48,9 @@ For yarn please run:
   **-b --blueprintId** - The Blueprint id you would like to deploy with
 
   **-e --environmentName** - The environment name you would like to create, if it exists it will deploy to that environment
-
+  
+  **-q --sensitiveEnvironmentName** - The sensitive environment name you would like to create, if it exists it will deploy to that environment
+    
   **-v --environmentVariables** - The environment variables to set on the deployed environment - works only on deploy and can be multiple, the format is "environmentVariableName1=value" 
   
   **-r --revision** - You git revision, can be a branch tag or a commit hash. Default value `master`

--- a/node/env0-deploy-cli.js
+++ b/node/env0-deploy-cli.js
@@ -11,7 +11,7 @@ const optionDefinitions = [
   { name: 'blueprintId', alias: 'b', type: String, description: 'The Blueprint id you would like to deploy' },
   { name: 'environmentName', alias: 'e', type: String, description: 'The environment name you would like to create, if it exists it will deploy to that environment' },
   { name: 'environmentVariables', alias: 'v', type: String, multiple: true, defaultValue: [], description: 'The environment variables to set on the deployed environment - works only on deploy and can be multiple, the format is "environmentVariableName1=value"' },
-  { name: 'sensitiveEnvironmentVariables', alias: 'vs', type: String, multiple: true, defaultValue: [], description: 'The sensitive environment variables to set on the deployed environment - works only on deploy and can be multiple, the format is "environmentVariableName1=value"' },
+  { name: 'sensitiveEnvironmentVariables', alias: 'q', type: String, multiple: true, defaultValue: [], description: 'The sensitive environment variables to set on the deployed environment - works only on deploy and can be multiple, the format is "environmentVariableName1=value"' },
 
   { name: 'revision', alias: 'r', type: String, defaultValue: 'master', description: 'Your git revision, can be a branch tag or a commit hash. Default value "master" ' },
   { name: 'archiveAfterDestroy',  type: Boolean, defaultValue: false, description: 'Archive the environment after a successful destroy' },

--- a/node/tests/env0-deploy-cli.spec.js
+++ b/node/tests/env0-deploy-cli.spec.js
@@ -22,7 +22,7 @@ describe("env0-deploy-cli", () => {
             { name: 'key2', value: 'value2', sensitive: false},
             { name: 'sensitiveKey1', value: 'sensitiveValue1', sensitive: true},
             { name: 'sensitiveKey2', value: 'sensitiveValue2', sensitive: true}
-        ]
+        ];
 
         expect(runDeployment).toBeCalledWith(mockOptions, expect.arrayContaining(expected));
     })

--- a/node/tests/env0-deploy-cli.spec.js
+++ b/node/tests/env0-deploy-cli.spec.js
@@ -14,9 +14,6 @@ const runDeployment = require('../env0-deploy-flow');
 const run = require('../env0-deploy-cli');
 
 describe("env0-deploy-cli", () => {
-    beforeEach(() => {
-
-    })
     it('should call run deployment with proper environment variables', async () => {
         await run();
 
@@ -24,8 +21,7 @@ describe("env0-deploy-cli", () => {
             { name: 'key1', value: 'value1', sensitive: false},
             { name: 'key2', value: 'value2', sensitive: false},
             { name: 'sensitiveKey1', value: 'sensitiveValue1', sensitive: true},
-            { name: 'sensitiveKey2', value: 'sensitiveValue2', sensitive: true},
-
+            { name: 'sensitiveKey2', value: 'sensitiveValue2', sensitive: true}
         ]
 
         expect(runDeployment).toBeCalledWith(mockOptions, expect.arrayContaining(expected));


### PR DESCRIPTION
### Issue
`command-line-args` package only supports aliases as one character, while sensitive environment variables where set to `-vs`

### Solution
Changed it to `-q`