### PR TITLE
Chore: update destroy env api

### DIFF
--- a/node/env0-deploy-utils.js
+++ b/node/env0-deploy-utils.js
@@ -63,7 +63,7 @@ class DeployUtils {
 
   async destroyEnvironment(environment) {
     console.log(`Starting to destroy environmentId: ${environment.id}`);
-    const deployment = await apiClient.callApi('delete', `environments/deployments/${environment.latestDeploymentLogId}`);
+    const deployment = await apiClient.callApi('post', `environments/${environment.id}/destroy`);
     console.log(`Started destroy ${deployment.id}`);
   }
 


### PR DESCRIPTION
Destroy API has been refactored in https://github.com/env0/env0/pull/1841 and should be updated in CLI.