### PR TITLE
Fix: config manager doesn't create directory

### DIFF
--- a/node/src/commons/config-manager.js
+++ b/node/src/commons/config-manager.js
@@ -58,7 +58,7 @@ const write = (options) => {
     const reduced = pick(options, INCLUDED_OPTIONS);
 
     console.log('Writing configuration to disk...');
-    fs.writeJsonSync(CONFIG_FILE, reduced, { spaces: 2 });
+    fs.outputJsonSync(CONFIG_FILE, reduced, { spaces: 2 });
 }
 
 module.exports = {

--- a/node/tests/commons/config-manager.spec.js
+++ b/node/tests/commons/config-manager.spec.js
@@ -69,7 +69,7 @@ describe('config manager', () => {
         it('should write ONLY required options to disk', () => {
             configManager.write({ ...mockOptions, another: 'option', 'and-another': 'option' })
 
-            expect(fs.writeJsonSync).toBeCalledWith(expect.any(String), mockOptions, { spaces: 2 });
+            expect(fs.outputJsonSync).toBeCalledWith(expect.any(String), mockOptions, { spaces: 2 });
         })
 
     })


### PR DESCRIPTION
### Issue & Steps to Reproduce
When deployment finishes, we write the configuration to a file under the user's home folder.
If folder doesn't exist, `fs-extra`'s `writeJsonSync` throws.

### Solution
change `fs-extra`'s `writeJsonSync` to `outputJsonSync`

