### PR TITLE
Fix: CLI version command clash with env vars

### DIFF
--- a/node/src/env0-deploy-cli.js
+++ b/node/src/env0-deploy-cli.js
@@ -105,7 +105,7 @@ const isInternalCommand = (command, args) => {
     return true;
   }
 
-  if (['-v', '--version'].some(h => args.includes(h)) || command === 'version') {
+  if (['--version'].some(h => args.includes(h)) || command === 'version') {
     console.log(version);
     return true;
   }

--- a/node/tests/env0-deploy-cli.spec.js
+++ b/node/tests/env0-deploy-cli.spec.js
@@ -64,7 +64,6 @@ describe("env0-deploy-cli", () => {
 
         describe.each`
         command
-        ${'-v'}
         ${'--version'}
         ${'version'}
         `('when user asks to see the version with $command', ({ command }) => {


### PR DESCRIPTION
### Issue & Steps to Reproduce
After adding #27, there's a clash with `-v` for environment variables.

### Solution
Remove `-v` for showing the version.

