### PR TITLE
Feat: require approval deployment + approve/cancel commands

### DIFF
--- a/node/src/commons/arguments.js
+++ b/node/src/commons/arguments.js
@@ -31,5 +31,5 @@ const argumentsMap = {
 module.exports = {
     argumentsMap,
     allArguments: Object.values(argumentsMap),
-    baseArguments: [ argumentsMap[API_KEY], argumentsMap[API_SECRET], argumentsMap[ORGANIZATION_ID], argumentsMap[PROJECT_ID] ]
+    baseArguments: [ argumentsMap[API_KEY], argumentsMap[API_SECRET], argumentsMap[ORGANIZATION_ID], argumentsMap[PROJECT_ID], argumentsMap[ENVIRONMENT_NAME] ]
 };

--- a/node/src/commons/arguments.js
+++ b/node/src/commons/arguments.js
@@ -31,5 +31,5 @@ const argumentsMap = {
 module.exports = {
     argumentsMap,
     allArguments: Object.values(argumentsMap),
-    baseArguments: [ argumentsMap[API_KEY], argumentsMap[API_KEY], argumentsMap[ORGANIZATION_ID], argumentsMap[PROJECT_ID] ]
+    baseArguments: [ argumentsMap[API_KEY], argumentsMap[API_SECRET], argumentsMap[ORGANIZATION_ID], argumentsMap[PROJECT_ID] ]
 };

--- a/node/src/commons/arguments.js
+++ b/node/src/commons/arguments.js
@@ -29,7 +29,6 @@ const argumentsMap = {
 };
 
 module.exports = {
-    argumentsMap,
     allArguments: Object.values(argumentsMap),
     baseArguments: [ argumentsMap[API_KEY], argumentsMap[API_SECRET], argumentsMap[ORGANIZATION_ID], argumentsMap[PROJECT_ID], argumentsMap[ENVIRONMENT_NAME] ]
 };

--- a/node/src/commons/arguments.js
+++ b/node/src/commons/arguments.js
@@ -1,0 +1,35 @@
+const { OPTIONS } = require('./constants');
+
+const {
+    API_KEY,
+    API_SECRET,
+    ORGANIZATION_ID,
+    PROJECT_ID,
+    BLUEPRINT_ID,
+    ENVIRONMENT_NAME,
+    ENVIRONMENT_VARIABLES,
+    SENSITIVE_ENVIRONMENT_VARIABLES,
+    REVISION,
+    ARCHIVE_AFTER_DESTROY,
+    REQUIRES_APPROVAL
+} = OPTIONS;
+
+const argumentsMap = {
+    [API_KEY]: { name: API_KEY, alias: 'k', type: String, description: 'Your env0 API Key' },
+    [API_SECRET]: { name: API_SECRET, alias: 's', type: String, description: 'Your env0 API Secret' },
+    [ORGANIZATION_ID]: { name: ORGANIZATION_ID, alias: 'o', type: String, description: 'Your env0 Organization id' },
+    [PROJECT_ID]: { name: PROJECT_ID, alias: 'p', type: String, description: 'Your env0 Project id' },
+    [BLUEPRINT_ID]: { name: BLUEPRINT_ID, alias: 'b', type: String, description: 'The Blueprint id you would like to deploy' },
+    [ENVIRONMENT_NAME]: { name: ENVIRONMENT_NAME, alias: 'e', type: String, description: 'The environment name you would like to create, if it exists it will deploy to that environment' },
+    [REQUIRES_APPROVAL]: { name: REQUIRES_APPROVAL, alias: 'a', type: Boolean, defaultValue: false, description: 'Whether deployment should wait for approval on plan stage before deploying your environment' },
+    [ENVIRONMENT_VARIABLES]: { name: ENVIRONMENT_VARIABLES, alias: 'v', type: String, multiple: true, defaultValue: [], description: 'The environment variables to set on the deployed environment - works only on deploy and can be multiple, the format is "environmentVariableName1=value"' },
+    [SENSITIVE_ENVIRONMENT_VARIABLES]: { name: SENSITIVE_ENVIRONMENT_VARIABLES, alias: 'q', type: String, multiple: true, defaultValue: [], description: 'The sensitive environment variables to set on the deployed environment - works only on deploy and can be multiple, the format is "environmentVariableName1=value"' },
+    [REVISION]: { name: REVISION, alias: 'r', type: String, defaultValue: 'master', description: 'Your git revision, can be a branch tag or a commit hash. Default value "master" ' },
+    [ARCHIVE_AFTER_DESTROY]: { name: ARCHIVE_AFTER_DESTROY, type: Boolean, defaultValue: false, description: 'Archive the environment after a successful destroy' },
+};
+
+module.exports = {
+    argumentsMap,
+    allArguments: Object.values(argumentsMap),
+    baseArguments: [ argumentsMap[API_KEY], argumentsMap[API_KEY], argumentsMap[ORGANIZATION_ID], argumentsMap[PROJECT_ID] ]
+};

--- a/node/src/commons/config-manager.js
+++ b/node/src/commons/config-manager.js
@@ -58,8 +58,6 @@ const read = (configFromParams) => {
 
 const write = (options) => {
     const reduced = pick(options, INCLUDED_OPTIONS);
-
-    console.log('Writing configuration to disk...');
     fs.outputJsonSync(CONFIG_FILE, reduced, { spaces: 2 });
 }
 

--- a/node/src/commons/constants.js
+++ b/node/src/commons/constants.js
@@ -8,7 +8,8 @@ const OPTIONS = {
     ENVIRONMENT_VARIABLES: 'environmentVariables',
     SENSITIVE_ENVIRONMENT_VARIABLES: 'sensitiveEnvironmentVariables',
     REVISION: 'revision',
-    ARCHIVE_AFTER_DESTROY: 'archiveAfterDestroy'
+    ARCHIVE_AFTER_DESTROY: 'archiveAfterDestroy',
+    REQUIRES_APPROVAL: 'requiresApproval'
 };
 
 module.exports = {

--- a/node/src/env0-deploy-cli.js
+++ b/node/src/env0-deploy-cli.js
@@ -109,9 +109,9 @@ const run = async () => {
   const mainOptions = commandLineArgs(mainDefinitions, { stopAtFirstUnknown: true });
   const argv = mainOptions._unknown || [];
 
-  try {
-    const { command } = mainOptions;
+  const { command } = mainOptions;
 
+  try {
     if (isInternalCommand(command, argv)) return;
 
     assertCommandExists(command);
@@ -122,6 +122,7 @@ const run = async () => {
 
     await runCommand(command, commandOptions, environmentVariables);
   } catch (error) {
+    console.error(`Command ${command} has failed. Error:`);
     let { message } = error;
     if (error.response && error.response.data && error.response.data.message) {
       message += `: ${error.response.data.message}`

--- a/node/src/env0-deploy-cli.js
+++ b/node/src/env0-deploy-cli.js
@@ -3,6 +3,7 @@ const commandLineUsage = require('command-line-usage');
 const runCommand = require('./env0-deploy-flow');
 const boxen = require('boxen');
 const { OPTIONS } = require('./commons/constants');
+const { argumentsMap, allArguments, baseArguments } = require('./commons/arguments');
 
 const mainDefinitions = [
   { name: 'command', defaultOption: true },
@@ -17,31 +18,24 @@ const {
   ENVIRONMENT_NAME,
   ENVIRONMENT_VARIABLES,
   SENSITIVE_ENVIRONMENT_VARIABLES,
-  REVISION,
-  ARCHIVE_AFTER_DESTROY
 } = OPTIONS;
-
-const optionDefinitions = [
-  { name: API_KEY, alias: 'k', type: String, description: 'Your env0 API Key' },
-  { name: API_SECRET, alias: 's', type: String, description: 'Your env0 API Secret' },
-  { name: ORGANIZATION_ID, alias: 'o', type: String, description: 'Your env0 Organization id' },
-  { name: PROJECT_ID, alias: 'p', type: String, description: 'Your env0 Project id' },
-  { name: BLUEPRINT_ID, alias: 'b', type: String, description: 'The Blueprint id you would like to deploy' },
-  { name: ENVIRONMENT_NAME, alias: 'e', type: String, description: 'The environment name you would like to create, if it exists it will deploy to that environment' },
-  { name: ENVIRONMENT_VARIABLES, alias: 'v', type: String, multiple: true, defaultValue: [], description: 'The environment variables to set on the deployed environment - works only on deploy and can be multiple, the format is "environmentVariableName1=value"' },
-  { name: SENSITIVE_ENVIRONMENT_VARIABLES, alias: 'q', type: String, multiple: true, defaultValue: [], description: 'The sensitive environment variables to set on the deployed environment - works only on deploy and can be multiple, the format is "environmentVariableName1=value"' },
-  { name: REVISION, alias: 'r', type: String, defaultValue: 'master', description: 'Your git revision, can be a branch tag or a commit hash. Default value "master" ' },
-  { name: ARCHIVE_AFTER_DESTROY, type: Boolean, defaultValue: false, description: 'Archive the environment after a successful destroy' },
-];
 
 const availableCommands = {
   'deploy': {
-    options: optionDefinitions,
+    options: allArguments,
     description: 'Deploys an environment'
   },
   'destroy': {
-    options: optionDefinitions,
+    options: allArguments,
     description: 'Destroys an environment'
+  },
+  'approve': {
+    options: [ ...baseArguments, argumentsMap[ENVIRONMENT_NAME] ],
+    description: 'Accepts a deployment that is pending approval'
+  },
+  'cancel': {
+    options: [ ...baseArguments, argumentsMap[ENVIRONMENT_NAME] ],
+    description: 'Cancels an deployment that is pending approval'
   },
   'help': {
     description: 'Shows this help message'
@@ -81,7 +75,7 @@ const sections = [
   },
   {
     header: 'Options',
-    optionList: optionDefinitions.map(option => ({
+    optionList: allArguments.map(option => ({
       ...option,
     }))
   }

--- a/node/src/env0-deploy-cli.js
+++ b/node/src/env0-deploy-cli.js
@@ -4,7 +4,7 @@ const runCommand = require('./env0-deploy-flow');
 const boxen = require('boxen');
 const { OPTIONS } = require('./commons/constants');
 const { version } = require('../package.json');
-const { argumentsMap, allArguments, baseArguments } = require('./commons/arguments');
+const { allArguments, baseArguments } = require('./commons/arguments');
 
 const mainDefinitions = [
   { name: 'command', defaultOption: true },
@@ -31,11 +31,11 @@ const availableCommands = {
     description: 'Destroys an environment'
   },
   'approve': {
-    options: [ ...baseArguments, argumentsMap[ENVIRONMENT_NAME] ],
+    options: baseArguments,
     description: 'Accepts a deployment that is pending approval'
   },
   'cancel': {
-    options: [ ...baseArguments, argumentsMap[ENVIRONMENT_NAME] ],
+    options: baseArguments,
     description: 'Cancels an deployment that is pending approval'
   },
   'version': {

--- a/node/src/env0-deploy-flow.js
+++ b/node/src/env0-deploy-flow.js
@@ -17,6 +17,11 @@ const assertRequiredOptions = (options) => {
   }
 }
 
+const getAndAssertAnExistingEnvironment = async (options) => {
+  const environment = await deployUtils.getEnvironment(options.environmentName, options.projectId);
+  if (!environment) throw new Error(`Could not find an environment with the name ${options.environmentName}`);
+}
+
 const runCommand = async (command, options, environmentVariables) => {
   options = configManager.read(options);
   assertRequiredOptions(options);
@@ -25,7 +30,9 @@ const runCommand = async (command, options, environmentVariables) => {
 
   const commands = {
     destroy: destroy,
-    deploy: createAndDeploy
+    deploy: createAndDeploy,
+    approve: setDeploymentApprovalStatus('approve'),
+    cancel: setDeploymentApprovalStatus('cancel')
   }
 
   await DeployUtils.init(options);
@@ -33,6 +40,10 @@ const runCommand = async (command, options, environmentVariables) => {
 
   configManager.write(options);
 };
+
+const setDeploymentApprovalStatus = (command) => async (options) => {
+  const environment = await getAndAssertAnExistingEnvironment(options);
+}
 
 const createAndDeploy = async (options, environmentVariables) => {
   console.log('Starting deployment');

--- a/node/src/env0-deploy-flow.js
+++ b/node/src/env0-deploy-flow.js
@@ -27,7 +27,8 @@ const runCommand = async (command, options, environmentVariables) => {
   options = configManager.read(options);
   assertRequiredOptions(options);
 
-  console.log(`Running ${command} with the following arguments:`, options);
+  console.log(`Running ${command} with the following arguments:`);
+  Object.keys(options).forEach(opt => console.log(`$ ${opt}: ${options[opt]}`));
 
   const commands = {
     destroy: destroy,
@@ -40,6 +41,7 @@ const runCommand = async (command, options, environmentVariables) => {
 
   console.log('Waiting for deployment to start...')
   await commands[command](options, environmentVariables);
+  console.log(`Command ${command} has finished successfully.`);
 
   configManager.write(options);
 };

--- a/node/src/env0-deploy-utils.js
+++ b/node/src/env0-deploy-utils.js
@@ -221,6 +221,7 @@ class DeployUtils {
       "CANCELLED",
       "ABORTED",
     ];
+
     const maxRetryNumber = 180; // waiting for 15 minutes (180 * 5 seconds)
     let retryCount = 0;
     let status;

--- a/node/src/env0-deploy-utils.js
+++ b/node/src/env0-deploy-utils.js
@@ -1,4 +1,4 @@
-const Env0ApiClient = require('./commons/api-client');
+const Env0ApiClient = require("./commons/api-client");
 
 class DeployUtils {
   constructor() {
@@ -10,33 +10,48 @@ class DeployUtils {
   }
 
   async getEnvironment(environmentName, projectId) {
-    const environments = await this.apiClient.callApi('get', `environments?projectId=${projectId}`);
+    const environments = await this.apiClient.callApi(
+      "get",
+      `environments?projectId=${projectId}`
+    );
 
-    return environments.find(env => env.name === environmentName);
+    return environments.find((env) => env.name === environmentName);
   }
 
   async createEnvironment(environmentName, organizationId, projectId) {
-    const environment = await this.apiClient.callApi('post', 'environments', {
+    const environment = await this.apiClient.callApi("post", "environments", {
       data: {
         name: environmentName,
         organizationId: organizationId,
         projectId: projectId,
-        lifespanEndAt: null
-      }
+        lifespanEndAt: null,
+      },
     });
     console.log(`Created environment ${environment.id}`);
     return environment;
   }
 
   async approveDeployment(deploymentLogId) {
-    await this.apiClient.callApi('put', `environments/deployments/${deploymentLogId}`);
+    await this.apiClient.callApi(
+      "put",
+      `environments/deployments/${deploymentLogId}`
+    );
   }
 
   async cancelDeployment(deploymentLogId) {
-    await this.apiClient.callApi('put', `environments/deployments/${deploymentLogId}/cancel`);
+    await this.apiClient.callApi(
+      "put",
+      `environments/deployments/${deploymentLogId}/cancel`
+    );
   }
 
-  async setConfiguration(environment, blueprintId, configurationName, configurationValue, isSensitive) {
+  async setConfiguration(
+    environment,
+    blueprintId,
+    configurationName,
+    configurationValue,
+    isSensitive
+  ) {
     const configuration = {
       isSensitive,
       name: configurationName,
@@ -44,51 +59,91 @@ class DeployUtils {
       scope: "ENVIRONMENT",
       scopeId: environment.id,
       type: 0,
-      value: configurationValue
+      value: configurationValue,
     };
 
     console.log(`getting configuration for environmentId: ${environment.id}`);
-    const params = { organizationId: environment.organizationId, blueprintId, environmentId: environment.id };
-    const configurations = await this.apiClient.callApi('get', 'configuration', { params });
-    const existingConfiguration = configurations.find(config => config.name === configurationName);
+    const params = {
+      organizationId: environment.organizationId,
+      blueprintId,
+      environmentId: environment.id,
+    };
+    const configurations = await this.apiClient.callApi(
+      "get",
+      "configuration",
+      { params }
+    );
+    const existingConfiguration = configurations.find(
+      (config) => config.name === configurationName
+    );
 
     if (existingConfiguration) {
-      console.log(`found a configuration that matches the configurationName: ${configurationName}, existingConfiguration: ${JSON.stringify(existingConfiguration)}`);
+      console.log(
+        `found a configuration that matches the configurationName: ${configurationName}, existingConfiguration: ${JSON.stringify(
+          existingConfiguration
+        )}`
+      );
       configuration.id = existingConfiguration.id;
     }
 
-    console.log(`setting the following configuration: ${JSON.stringify(configuration)}`);
-    await this.apiClient.callApi('post', 'configuration', {data: {...configuration, projectId: undefined}});
+    console.log(
+      `setting the following configuration: ${JSON.stringify(configuration)}`
+    );
+    await this.apiClient.callApi("post", "configuration", {
+      data: { ...configuration, projectId: undefined },
+    });
   }
 
-  async deployEnvironment(environment, blueprintRevision, blueprintId, requiresApproval) {
+  async deployEnvironment(
+    environment,
+    blueprintRevision,
+    blueprintId,
+    requiresApproval
+  ) {
     await this.waitForEnvironment(environment.id);
 
     return await this.apiClient.callApi(
-        'post',
-        `environments/${environment.id}/deployments`,
-        { data: { blueprintId, blueprintRevision, userRequiresApproval: requiresApproval } });
+      "post",
+      `environments/${environment.id}/deployments`,
+      {
+        data: {
+          blueprintId,
+          blueprintRevision,
+          userRequiresApproval: requiresApproval,
+        },
+      }
+    );
   }
 
   async destroyEnvironment(environment) {
     await this.waitForEnvironment(environment.id);
 
-    return await this.apiClient.callApi('post', `environments/${environment.id}/destroy`);
+    return await this.apiClient.callApi(
+      "post",
+      `environments/${environment.id}/destroy`
+    );
   }
 
   async writeDeploymentStepLog(deploymentLogId, stepName) {
     let shouldPoll, startTime;
 
     do {
-      const steps = await this.apiClient.callApi('get', `deployments/${deploymentLogId}/steps`);
-      const { status } = steps.find(step => step.name === stepName);
-      const stepInProgress = status === 'IN_PROGRESS';
+      const steps = await this.apiClient.callApi(
+        "get",
+        `deployments/${deploymentLogId}/steps`
+      );
+      const { status } = steps.find((step) => step.name === stepName);
+      const stepInProgress = status === "IN_PROGRESS";
 
-      const { events, nextStartTime, hasMoreLogs } = await this.apiClient.callApi(
-          'get',
-          `deployments/${deploymentLogId}/steps/${stepName}/log`,
-          { params: { startTime }}
-          );
+      const {
+        events,
+        nextStartTime,
+        hasMoreLogs,
+      } = await this.apiClient.callApi(
+        "get",
+        `deployments/${deploymentLogId}/steps/${stepName}/log`,
+        { params: { startTime } }
+      );
 
       events.forEach((event) => console.log(event.message));
 
@@ -96,20 +151,23 @@ class DeployUtils {
       if (stepInProgress) await this.apiClient.sleep(1000);
 
       shouldPoll = hasMoreLogs || stepInProgress;
-    } while (shouldPoll)
+    } while (shouldPoll);
   }
 
   async processDeploymentSteps(deploymentLogId, stepsToSkip) {
     const doneSteps = [];
 
-    const steps = await this.apiClient.callApi('get', `deployments/${deploymentLogId}/steps`);
+    const steps = await this.apiClient.callApi(
+      "get",
+      `deployments/${deploymentLogId}/steps`
+    );
 
     for (const step of steps) {
       const alreadyLogged = stepsToSkip.includes(step.name);
 
-      if (!alreadyLogged && step.status !== 'NOT_STARTED') {
+      if (!alreadyLogged && step.status !== "NOT_STARTED") {
         console.log(`$$$ ${step.name}`);
-        console.log('#'.repeat(100));
+        console.log("#".repeat(100));
         await this.writeDeploymentStepLog(deploymentLogId, step.name);
 
         doneSteps.push(step.name);
@@ -120,44 +178,72 @@ class DeployUtils {
   }
 
   async pollDeploymentStatus(deploymentLogId) {
-    const MAX_TIME_IN_SECONDS = 10800 // 3 hours
+    const MAX_TIME_IN_SECONDS = 10800; // 3 hours
     const start = Date.now();
     const stepsAlreadyLogged = [];
 
     while (true) {
-      const { status } = await this.apiClient.callApi('get', `environments/deployments/${deploymentLogId}`);
+      const { status } = await this.apiClient.callApi(
+        "get",
+        `environments/deployments/${deploymentLogId}`
+      );
 
-      stepsAlreadyLogged.push(...await this.processDeploymentSteps(deploymentLogId, stepsAlreadyLogged));
+      stepsAlreadyLogged.push(
+        ...(await this.processDeploymentSteps(
+          deploymentLogId,
+          stepsAlreadyLogged
+        ))
+      );
 
-      if (status !== 'IN_PROGRESS') {
-        status === 'WAITING_FOR_USER' && console.log('Deployment is waiting for an approval. Run \'env0 approve\' or \'env0 cancel\' to continue.');
+      if (status !== "IN_PROGRESS") {
+        status === "WAITING_FOR_USER" &&
+          console.log(
+            "Deployment is waiting for an approval. Run 'env0 approve' or 'env0 cancel' to continue."
+          );
         return status;
       }
 
       const elapsedTimeInSeconds = (Date.now() - start) / 1000;
-      if (elapsedTimeInSeconds > MAX_TIME_IN_SECONDS) throw new Error('Polling deployment timed out');
+      if (elapsedTimeInSeconds > MAX_TIME_IN_SECONDS)
+        throw new Error("Polling deployment timed out");
 
       await this.apiClient.sleep(2000);
     }
   }
 
   async waitForEnvironment(environmentId) {
-    const environmentValidStatuses = ['CREATED', 'ACTIVE', 'INACTIVE', 'FAILED', 'TIMEOUT'];
+    const environmentValidStatuses = [
+      "CREATED",
+      "ACTIVE",
+      "INACTIVE",
+      "FAILED",
+      "TIMEOUT",
+      "CANCELLED",
+      "ABORTED",
+    ];
     const maxRetryNumber = 180; // waiting for 15 minutes (180 * 5 seconds)
     let retryCount = 0;
     let status;
 
     do {
-      ({ status } = await this.apiClient.callApi('get', `environments/${environmentId}`));
+      ({ status } = await this.apiClient.callApi(
+        "get",
+        `environments/${environmentId}`
+      ));
 
-      if (status === 'WAITING_FOR_USER') {
-        throw new Error('Deployment is waiting for an approval. Run \'env0 approve\' or \'env0 cancel\' to continue.');
+      if (status === "WAITING_FOR_USER") {
+        throw new Error(
+          "Deployment is waiting for an approval. Run 'env0 approve' or 'env0 cancel' to continue."
+        );
       }
 
       if (environmentValidStatuses.includes(status)) return;
-      if (retryCount >= maxRetryNumber) throw new Error('Polling environment timed out');
+      if (retryCount >= maxRetryNumber)
+        throw new Error("Polling environment timed out");
 
-      console.log(`Waiting for environment to become deployable. (current status: ${status})`);
+      console.log(
+        `Waiting for environment to become deployable. (current status: ${status})`
+      );
 
       retryCount++;
       await this.apiClient.sleep(5000);
@@ -166,9 +252,12 @@ class DeployUtils {
 
   async archiveIfInactive(environmentId) {
     const envRoute = `environments/${environmentId}`;
-    const environment = await this.apiClient.callApi('get', envRoute);
-    if (environment.status !== 'INACTIVE') throw new Error('Environment did not reach INACTIVE status');
-    await this.apiClient.callApi('put', envRoute, { data: { isArchived: true }});
+    const environment = await this.apiClient.callApi("get", envRoute);
+    if (environment.status !== "INACTIVE")
+      throw new Error("Environment did not reach INACTIVE status");
+    await this.apiClient.callApi("put", envRoute, {
+      data: { isArchived: true },
+    });
     console.log(`Environment ${environment.name} has been archived`);
   }
 }

--- a/node/tests/env0-deploy-utils.spec.js
+++ b/node/tests/env0-deploy-utils.spec.js
@@ -1,13 +1,16 @@
 const DeployUtils = require("../src/env0-deploy-utils");
 
 jest.mock("../src/commons/api-client", () =>
-    jest.fn().mockImplementation(() => ({ callApi: mockCallApi, sleep: () => Promise.resolve() }))
+  jest.fn().mockImplementation(() => ({
+    callApi: mockCallApi,
+    sleep: () => Promise.resolve(),
+  }))
 );
 
 const mockCallApi = jest.fn();
 
-const mockEnvironmentId = 'environment0';
-const mockDeploymentId = 'deployment0';
+const mockEnvironmentId = "environment0";
+const mockDeploymentId = "deployment0";
 
 describe("env0-deploy-utils", () => {
   const deployUtils = new DeployUtils();
@@ -16,226 +19,291 @@ describe("env0-deploy-utils", () => {
     mockCallApi.mockClear();
   });
 
-  describe('set configuration', () => {
+  describe("set configuration", () => {
     beforeEach(() => {
       mockCallApi.mockResolvedValue([]);
     });
 
-    it('should query existing configurations for update', async () => {
+    it("should query existing configurations for update", async () => {
       await deployUtils.setConfiguration(
-          {id:'environment-1', organizationId: 'organization-1'},
-          'blueprint-1',
-          'variable-name',
-          'variable-value',
-          false
+        { id: "environment-1", organizationId: "organization-1" },
+        "blueprint-1",
+        "variable-name",
+        "variable-value",
+        false
       );
 
-      expect(mockCallApi).toHaveBeenCalledWith(
-          'get',
-          'configuration',
-          {params: {blueprintId: 'blueprint-1', environmentId: 'environment-1', organizationId: 'organization-1'}}
-      );
+      expect(mockCallApi).toHaveBeenCalledWith("get", "configuration", {
+        params: {
+          blueprintId: "blueprint-1",
+          environmentId: "environment-1",
+          organizationId: "organization-1",
+        },
+      });
     });
 
-    it('should post configuration property without id when new', async () => {
+    it("should post configuration property without id when new", async () => {
       await deployUtils.setConfiguration(
-          {id:'environment-1', organizationId: 'organization-1'},
-          'blueprint-1',
-          'variable-name',
-          'variable-value',
-          false
+        { id: "environment-1", organizationId: "organization-1" },
+        "blueprint-1",
+        "variable-name",
+        "variable-value",
+        false
       );
 
-      expect(mockCallApi).toHaveBeenCalledWith(
-          'post',
-          'configuration',
-          {
-            data: expect.objectContaining({
-              isSensitive: false,
-              name: 'variable-name',
-              organizationId: 'organization-1',
-              projectId: undefined,
-              scope: "ENVIRONMENT",
-              scopeId: 'environment-1',
-              type: 0,
-              value: "variable-value",
-            })
-          }
-      );
+      expect(mockCallApi).toHaveBeenCalledWith("post", "configuration", {
+        data: expect.objectContaining({
+          isSensitive: false,
+          name: "variable-name",
+          organizationId: "organization-1",
+          projectId: undefined,
+          scope: "ENVIRONMENT",
+          scopeId: "environment-1",
+          type: 0,
+          value: "variable-value",
+        }),
+      });
     });
 
     it.each`
-    isSensitive
-    ${true}
-    ${false}
-    `('should post configuration property with isSensitive: $isSensitive', async ({ isSensitive }) => {
-      await deployUtils.setConfiguration(
-          {id:'environment-1', organizationId: 'organization-1'},
-          'blueprint-1',
-          'variable-name',
-          'variable-value',
+      isSensitive
+      ${true}
+      ${false}
+    `(
+      "should post configuration property with isSensitive: $isSensitive",
+      async ({ isSensitive }) => {
+        await deployUtils.setConfiguration(
+          { id: "environment-1", organizationId: "organization-1" },
+          "blueprint-1",
+          "variable-name",
+          "variable-value",
           isSensitive
-      );
+        );
 
-      expect(mockCallApi).toHaveBeenCalledWith(
-          'post',
-          'configuration',
-          { data: expect.objectContaining({ isSensitive } ) }
-      );
-    })
+        expect(mockCallApi).toHaveBeenCalledWith("post", "configuration", {
+          data: expect.objectContaining({ isSensitive }),
+        });
+      }
+    );
   });
 
-  describe('wait for environment', () => {
+  describe("wait for environment", () => {
     it.each`
-    status
-    ${'CREATED'}
-    ${'INACTIVE'}
-    ${'ACTIVE'}
-    ${'FAILED'}
-    ${'TIMEOUT'}
-    `('should call api client once', async ({ status }) => {
+      status
+      ${"CREATED"}
+      ${"INACTIVE"}
+      ${"ACTIVE"}
+      ${"FAILED"}
+      ${"TIMEOUT"}
+    `("should call api client once", async ({ status }) => {
       mockCallApi.mockResolvedValue({ status });
 
       await deployUtils.waitForEnvironment(mockEnvironmentId);
 
-      expect(mockCallApi).toBeCalledWith('get', `environments/${mockEnvironmentId}`,);
+      expect(mockCallApi).toBeCalledWith(
+        "get",
+        `environments/${mockEnvironmentId}`
+      );
       expect(mockCallApi).toBeCalledTimes(1);
-    })
+    });
 
-    it('should call api client twice', async () => {
-      mockCallApi.mockResolvedValueOnce({ status: 'TEST' });
-      mockCallApi.mockResolvedValueOnce({ status: 'ACTIVE' });
+    it("should call api client twice", async () => {
+      mockCallApi.mockResolvedValueOnce({ status: "TEST" });
+      mockCallApi.mockResolvedValueOnce({ status: "ACTIVE" });
 
       await deployUtils.waitForEnvironment(mockEnvironmentId);
 
-      expect(mockCallApi).toBeCalledWith('get', `environments/${mockEnvironmentId}`,);
+      expect(mockCallApi).toBeCalledWith(
+        "get",
+        `environments/${mockEnvironmentId}`
+      );
       expect(mockCallApi).toBeCalledTimes(2);
-    })
+    });
   });
 
-  describe('poll deployment status', () => {
+  describe("poll deployment status", () => {
     beforeEach(() => {
       mockCallApi.mockResolvedValue([]);
     });
 
-    it('should call api and and return status', async () => {
-      const mockStatus = 'SUCCESS';
+    it("should call api and and return status", async () => {
+      const mockStatus = "SUCCESS";
       mockCallApi.mockResolvedValueOnce({ status: mockStatus });
 
       const status = await deployUtils.pollDeploymentStatus(mockDeploymentId);
 
-      expect(mockCallApi).toBeCalledWith('get', `environments/deployments/${mockDeploymentId}`);
+      expect(mockCallApi).toBeCalledWith(
+        "get",
+        `environments/deployments/${mockDeploymentId}`
+      );
       expect(status).toBe(mockStatus);
     });
   });
 
-  describe('write deployment steps', () => {
-    it('should call api', async () => {
+  describe("write deployment steps", () => {
+    it("should call api", async () => {
       mockCallApi.mockResolvedValue([]);
 
       await deployUtils.processDeploymentSteps(mockDeploymentId, []);
 
-      expect(mockCallApi).toBeCalledWith('get', `deployments/${mockDeploymentId}/steps`);
-    })
+      expect(mockCallApi).toBeCalledWith(
+        "get",
+        `deployments/${mockDeploymentId}/steps`
+      );
+    });
 
     it.each`
-    stepsFromApi | stepsToSkip
-    ${[ { name: 'git:clone', status: 'SUCCESS' } ]} | ${[ 'git:clone' ]}
-    ${[{ name: 'git:clone', status: 'NOT_STARTED' } ]} | ${[]}
-    `('should skip step log', async ({ stepsFromApi, stepsToSkip }) => {
+      stepsFromApi                                      | stepsToSkip
+      ${[{ name: "git:clone", status: "SUCCESS" }]}     | ${["git:clone"]}
+      ${[{ name: "git:clone", status: "NOT_STARTED" }]} | ${[]}
+    `("should skip step log", async ({ stepsFromApi, stepsToSkip }) => {
       mockCallApi.mockResolvedValue(stepsFromApi);
 
-      const doneSteps = await deployUtils.processDeploymentSteps(mockDeploymentId, stepsToSkip);
+      const doneSteps = await deployUtils.processDeploymentSteps(
+        mockDeploymentId,
+        stepsToSkip
+      );
 
       expect(doneSteps).toEqual([]);
-    })
+    });
 
-    it('should get step log', async () => {
-      const mockStep = { name: 'git:clone', status: 'SUCCESS' };
+    it("should get step log", async () => {
+      const mockStep = { name: "git:clone", status: "SUCCESS" };
 
-      mockCallApi.mockResolvedValueOnce([ mockStep ]);
-      mockCallApi.mockResolvedValueOnce([ mockStep ]); // mock for getting steps in write deployment step log function
+      mockCallApi.mockResolvedValueOnce([mockStep]);
+      mockCallApi.mockResolvedValueOnce([mockStep]); // mock for getting steps in write deployment step log function
       mockCallApi.mockResolvedValueOnce({ events: [] }); // mock for the write deployment step log function
 
-      const doneSteps = await deployUtils.processDeploymentSteps(mockDeploymentId, []);
+      const doneSteps = await deployUtils.processDeploymentSteps(
+        mockDeploymentId,
+        []
+      );
 
-      expect(doneSteps).toEqual([ mockStep.name ])
-    })
-  })
+      expect(doneSteps).toEqual([mockStep.name]);
+    });
+  });
 
-  describe('write deployment step log', () => {
-    const mockStep = { name: 'git:clone', status: 'SUCCESS' };
+  describe("write deployment step log", () => {
+    const mockStep = { name: "git:clone", status: "SUCCESS" };
 
-    it('should call api for once (both for getting steps and log = total of 2)', async () => {
-      mockCallApi.mockResolvedValueOnce([ mockStep ]);
+    it("should call api for once (both for getting steps and log = total of 2)", async () => {
+      mockCallApi.mockResolvedValueOnce([mockStep]);
       mockCallApi.mockResolvedValueOnce({ events: [], hasMoreLogs: false });
 
-      await deployUtils.writeDeploymentStepLog(mockDeploymentId, mockStep.name)
+      await deployUtils.writeDeploymentStepLog(mockDeploymentId, mockStep.name);
 
-      expect(mockCallApi).toBeCalledWith('get', `deployments/${mockDeploymentId}/steps/${mockStep.name}/log`, { params: { startTime: undefined }});
+      expect(mockCallApi).toBeCalledWith(
+        "get",
+        `deployments/${mockDeploymentId}/steps/${mockStep.name}/log`,
+        { params: { startTime: undefined } }
+      );
       expect(mockCallApi).toBeCalledTimes(2);
     });
 
     it.each`
-    when | hasMoreLogs | mockStep
-    ${'hasMore logs is true'} | ${true} | ${{ name: 'git:clone', status: 'SUCCESS' }}
-    ${'step is still in progress'} | ${false} | ${{ name: 'git:clone', status: 'IN_PROGRESS' }}
-    `('should call api twice (both for getting steps and log = total of 4) when $when', async ({ hasMoreLogs, mockStep }) => {
-      mockCallApi.mockResolvedValueOnce([ mockStep ]);
-      mockCallApi.mockResolvedValueOnce({ events: [], hasMoreLogs });
-      mockCallApi.mockResolvedValueOnce([ { ...mockStep, status: 'SUCCESS'} ]);
+      when                           | hasMoreLogs | mockStep
+      ${"hasMore logs is true"}      | ${true}     | ${{ name: "git:clone", status: "SUCCESS" }}
+      ${"step is still in progress"} | ${false}    | ${{ name: "git:clone", status: "IN_PROGRESS" }}
+    `(
+      "should call api twice (both for getting steps and log = total of 4) when $when",
+      async ({ hasMoreLogs, mockStep }) => {
+        mockCallApi.mockResolvedValueOnce([mockStep]);
+        mockCallApi.mockResolvedValueOnce({ events: [], hasMoreLogs });
+        mockCallApi.mockResolvedValueOnce([{ ...mockStep, status: "SUCCESS" }]);
+        mockCallApi.mockResolvedValueOnce({ events: [], hasMoreLogs: false });
+
+        await deployUtils.writeDeploymentStepLog(
+          mockDeploymentId,
+          mockStep.name
+        );
+
+        expect(mockCallApi).toBeCalledWith(
+          "get",
+          `deployments/${mockDeploymentId}/steps/${mockStep.name}/log`,
+          { params: { startTime: undefined } }
+        );
+        expect(mockCallApi).toBeCalledTimes(4);
+      }
+    );
+
+    it("should use nextStartTime from api on consecutive calls", async () => {
+      const mockNextStartTime = "party time";
+
+      mockCallApi.mockResolvedValueOnce([mockStep]);
+      mockCallApi.mockResolvedValueOnce({
+        events: [],
+        hasMoreLogs: true,
+        nextStartTime: mockNextStartTime,
+      });
+      mockCallApi.mockResolvedValueOnce([{ ...mockStep, status: "SUCCESS" }]);
       mockCallApi.mockResolvedValueOnce({ events: [], hasMoreLogs: false });
 
-      await deployUtils.writeDeploymentStepLog(mockDeploymentId, mockStep.name)
+      await deployUtils.writeDeploymentStepLog(mockDeploymentId, mockStep.name);
 
-      expect(mockCallApi).toBeCalledWith('get', `deployments/${mockDeploymentId}/steps/${mockStep.name}/log`, { params: { startTime: undefined }});
-      expect(mockCallApi).toBeCalledTimes(4);
+      expect(mockCallApi).toBeCalledWith(
+        "get",
+        `deployments/${mockDeploymentId}/steps/${mockStep.name}/log`,
+        { params: { startTime: undefined } }
+      );
+      expect(mockCallApi).toHaveBeenLastCalledWith(
+        "get",
+        `deployments/${mockDeploymentId}/steps/${mockStep.name}/log`,
+        { params: { startTime: mockNextStartTime } }
+      );
     });
-
-    it('should use nextStartTime from api on consecutive calls', async () => {
-      const mockNextStartTime = 'party time';
-
-      mockCallApi.mockResolvedValueOnce([ mockStep ]);
-      mockCallApi.mockResolvedValueOnce({ events: [], hasMoreLogs: true, nextStartTime: mockNextStartTime });
-      mockCallApi.mockResolvedValueOnce([ { ...mockStep, status: 'SUCCESS'} ]);
-      mockCallApi.mockResolvedValueOnce({ events: [], hasMoreLogs: false });
-
-      await deployUtils.writeDeploymentStepLog(mockDeploymentId, mockStep.name)
-
-
-      expect(mockCallApi).toBeCalledWith('get', `deployments/${mockDeploymentId}/steps/${mockStep.name}/log`, { params: { startTime: undefined }});
-      expect(mockCallApi).toHaveBeenLastCalledWith('get', `deployments/${mockDeploymentId}/steps/${mockStep.name}/log`, { params: { startTime: mockNextStartTime }});
-    })
   });
 
-  describe('deploy environment', async () => {
-    const mockEnvironment = { id: 'env0', status: 'SUCCESS' };
-    const mockBlueprintRevision = 'rev0';
-    const mockBlueprintId = 'blueprint0';
+  describe("deploy environment", async () => {
+    const mockEnvironment = { id: "env0", status: "ACTIVE" };
+    const mockBlueprintRevision = "rev0";
+    const mockBlueprintId = "blueprint0";
     const mockRequiresApproval = true;
 
-    await deployUtils.deployEnvironment(mockEnvironment, mockBlueprintRevision, mockBlueprintId, mockRequiresApproval);
+    beforeEach(() => {
+      mockCallApi.mockReturnValue(mockEnvironment);
+    });
 
-    expect(mockCallApi).toHaveBeenLastCalledWith(
-        'post',
+    it("should call api", async () => {
+      await deployUtils.deployEnvironment(
+        mockEnvironment,
+        mockBlueprintRevision,
+        mockBlueprintId,
+        mockRequiresApproval
+      );
+
+      expect(mockCallApi).toHaveBeenLastCalledWith(
+        "post",
         `environments/${mockEnvironment.id}/deployments`,
-        { data: { blueprintId: mockBlueprintId, blueprintRevision: mockBlueprintRevision, userRequiresApproval: mockRequiresApproval } }
-        )
-  })
-
-  describe('approve deployment', () => {
-    it('should call api', async () => {
-      await deployUtils.approveDeployment(mockDeploymentId);
-
-      expect(mockCallApi).toBeCalledWith('put', `environments/deployments/${mockDeploymentId}`);
+        {
+          data: {
+            blueprintId: mockBlueprintId,
+            blueprintRevision: mockBlueprintRevision,
+            userRequiresApproval: mockRequiresApproval,
+          },
+        }
+      );
     });
   });
 
-  describe('cancel deployment', () => {
-    it('should call api', async () => {
+  describe("approve deployment", () => {
+    it("should call api", async () => {
+      await deployUtils.approveDeployment(mockDeploymentId);
+
+      expect(mockCallApi).toBeCalledWith(
+        "put",
+        `environments/deployments/${mockDeploymentId}`
+      );
+    });
+  });
+
+  describe("cancel deployment", () => {
+    it("should call api", async () => {
       await deployUtils.cancelDeployment(mockDeploymentId);
 
-      expect(mockCallApi).toBeCalledWith('put', `environments/deployments/${mockDeploymentId}/cancel`);
+      expect(mockCallApi).toBeCalledWith(
+        "put",
+        `environments/deployments/${mockDeploymentId}/cancel`
+      );
     });
   });
 });

--- a/node/tests/env0-deploy-utils.spec.js
+++ b/node/tests/env0-deploy-utils.spec.js
@@ -95,6 +95,8 @@ describe("env0-deploy-utils", () => {
       ${"ACTIVE"}
       ${"FAILED"}
       ${"TIMEOUT"}
+      ${"CANCELLED"}
+      ${"ABORTED"}
     `("should call api client once", async ({ status }) => {
       mockCallApi.mockResolvedValue({ status });
 

--- a/node/tests/env0-deploy-utils.spec.js
+++ b/node/tests/env0-deploy-utils.spec.js
@@ -207,4 +207,35 @@ describe("env0-deploy-utils", () => {
       expect(mockCallApi).toHaveBeenLastCalledWith('get', `deployments/${mockDeploymentId}/steps/${mockStep.name}/log`, { params: { startTime: mockNextStartTime }});
     })
   });
+
+  describe('deploy environment', async () => {
+    const mockEnvironment = { id: 'env0', status: 'SUCCESS' };
+    const mockBlueprintRevision = 'rev0';
+    const mockBlueprintId = 'blueprint0';
+    const mockRequiresApproval = true;
+
+    await deployUtils.deployEnvironment(mockEnvironment, mockBlueprintRevision, mockBlueprintId, mockRequiresApproval);
+
+    expect(mockCallApi).toHaveBeenLastCalledWith(
+        'post',
+        `environments/${mockEnvironment.id}/deployments`,
+        { data: { blueprintId: mockBlueprintId, blueprintRevision: mockBlueprintRevision, userRequiresApproval: mockRequiresApproval } }
+        )
+  })
+
+  describe('approve deployment', () => {
+    it('should call api', async () => {
+      await deployUtils.approveDeployment(mockDeploymentId);
+
+      expect(mockCallApi).toBeCalledWith('put', `environments/deployments/${mockDeploymentId}`);
+    });
+  });
+
+  describe('cancel deployment', () => {
+    it('should call api', async () => {
+      await deployUtils.cancelDeployment(mockDeploymentId);
+
+      expect(mockCallApi).toBeCalledWith('put', `environments/deployments/${mockDeploymentId}/cancel`);
+    });
+  });
 });


### PR DESCRIPTION
### Feature Request
1. A user should be able to deploy/destroy an environment with some requires-approval flag.
2. A user should be able to approve an awaiting deployment from CLI.
3. A user should be able to cancel an awaiting deployment from CLI.

### Solution
1. New `--requireApproval` (`-a`) argument.
2. New `env0 approve` command.
3. New `env0 cancel` command.

