### PR TITLE
Chore: add logger and hide secrets

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -36,7 +36,8 @@
     "command-line-args": "^5.1.1",
     "command-line-usage": "^6.1.0",
     "fs-extra": "^9.0.1",
-    "lodash": "^4.17.19"
+    "lodash": "^4.17.19",
+    "winston": "^3.3.3"
   },
   "devDependencies": {
     "eslint": "^6.8.0",

--- a/node/package.json
+++ b/node/package.json
@@ -37,7 +37,7 @@
     "command-line-usage": "^6.1.0",
     "fs-extra": "^9.0.1",
     "inquirer": "^7.3.3",
-    "lodash": "^4.17.19"
+    "lodash": "^4.17.19",
     "winston": "^3.3.3"
   },
   "devDependencies": {

--- a/node/src/commands/deploy.js
+++ b/node/src/commands/deploy.js
@@ -1,11 +1,12 @@
 const DeployUtils = require('../lib/deploy-utils');
+const logger = require('../lib/logger');
 
 const setConfigurationFromOptions = async (environmentVariables, environment, blueprintId) => {
   const deployUtils = new DeployUtils();
 
   if (environmentVariables && environmentVariables.length > 0) {
     for (const config of environmentVariables) {
-      console.log(
+      logger.info(
         `Setting Environment Variable ${config.name} to be ${config.value} in environmentId: ${environment.id}`
       );
       await deployUtils.setConfiguration(environment, blueprintId, config.name, config.value, config.sensitive);

--- a/node/src/commands/run-command.js
+++ b/node/src/commands/run-command.js
@@ -5,6 +5,7 @@ const destroy = require('./destroy');
 const approve = require('./approve');
 const cancel = require('./cancel');
 const { options } = require('../config/constants');
+const logger = require('../lib/logger');
 
 const { API_KEY, API_SECRET, ORGANIZATION_ID, PROJECT_ID, ENVIRONMENT_NAME } = options;
 
@@ -24,8 +25,10 @@ const runCommand = async (command, options, environmentVariables) => {
   assertRequiredOptions(options);
   configManager.write(options);
 
-  console.log(`Running ${command} with the following arguments:`);
-  Object.keys(options).forEach(opt => console.log(`$ ${opt}: ${options[opt]}`));
+  logger.setSecrets(options);
+
+  logger.info(`Running ${command} with the following arguments:`);
+  Object.keys(options).forEach(opt => logger.info(`$ ${opt}: ${options[opt]}`));
 
   const commands = {
     destroy: destroy,
@@ -36,9 +39,9 @@ const runCommand = async (command, options, environmentVariables) => {
 
   await DeployUtils.init(options);
 
-  console.log('Waiting for deployment to start...');
+  logger.info('Waiting for deployment to start...');
   await commands[command](options, environmentVariables);
-  console.log(`Command ${command} has finished successfully.`);
+  logger.info(`Command ${command} has finished successfully.`);
 };
 
 module.exports = runCommand;

--- a/node/src/config/arguments.js
+++ b/node/src/config/arguments.js
@@ -15,13 +15,21 @@ const {
 } = options;
 
 const argumentsMap = {
-  [API_KEY]: { name: API_KEY, alias: 'k', type: String, description: 'env0 API Key', prompt: 'env0 API Key' },
+  [API_KEY]: {
+    name: API_KEY,
+    alias: 'k',
+    type: String,
+    description: 'env0 API Key',
+    prompt: 'env0 API Key',
+    secret: true
+  },
   [API_SECRET]: {
     name: API_SECRET,
     alias: 's',
     type: String,
     description: 'env0 API Secret',
-    prompt: 'env0 API Secret'
+    prompt: 'env0 API Secret',
+    secret: true
   },
   [ORGANIZATION_ID]: {
     name: ORGANIZATION_ID,

--- a/node/src/lib/config-manager.js
+++ b/node/src/lib/config-manager.js
@@ -3,6 +3,7 @@ const fs = require('fs-extra');
 const path = require('path');
 const { options } = require('../config/constants');
 const { pick } = require('lodash');
+const logger = require('./logger');
 
 const CONFIG_FILE = path.join(os.homedir(), '.env0', 'config.json');
 
@@ -29,7 +30,7 @@ const getEnvVars = () => {
   });
 
   const found = Object.keys(config);
-  if (found.length) console.log(`Found environment variables ${found}`);
+  if (found.length) logger.info(`Found environment variables ${found}`);
 
   return config;
 };
@@ -39,7 +40,7 @@ const read = configFromParams => {
   const configFromEnv = getEnvVars();
 
   if (fs.existsSync(CONFIG_FILE)) {
-    console.log('Found existing configuration');
+    logger.info('Found existing configuration');
     const raw = fs.readFileSync(CONFIG_FILE);
 
     try {

--- a/node/src/lib/deploy-utils.js
+++ b/node/src/lib/deploy-utils.js
@@ -1,4 +1,5 @@
 const Env0ApiClient = require('./api-client');
+const logger = require('./logger');
 
 const apiClient = new Env0ApiClient();
 
@@ -22,7 +23,7 @@ class DeployUtils {
         lifespanEndAt: null
       }
     });
-    console.log(`Created environment ${environment.id}`);
+    logger.info(`Created environment ${environment.id}`);
     return environment;
   }
 
@@ -45,7 +46,7 @@ class DeployUtils {
       value: configurationValue
     };
 
-    console.log(`getting configuration for environmentId: ${environment.id}`);
+    logger.info(`getting configuration for environmentId: ${environment.id}`);
     const params = {
       organizationId: environment.organizationId,
       blueprintId,
@@ -55,7 +56,7 @@ class DeployUtils {
     const existingConfiguration = configurations.find(config => config.name === configurationName);
 
     if (existingConfiguration) {
-      console.log(
+      logger.info(
         `found a configuration that matches the configurationName: ${configurationName}, existingConfiguration: ${JSON.stringify(
           existingConfiguration
         )}`
@@ -63,7 +64,7 @@ class DeployUtils {
       configuration.id = existingConfiguration.id;
     }
 
-    console.log(`setting the following configuration: ${JSON.stringify(configuration)}`);
+    logger.info(`setting the following configuration: ${JSON.stringify(configuration)}`);
     await apiClient.callApi('post', 'configuration', {
       data: { ...configuration, projectId: undefined }
     });
@@ -102,7 +103,7 @@ class DeployUtils {
         { params: { startTime } }
       );
 
-      events.forEach(event => console.log(event.message));
+      events.forEach(event => logger.info(event.message));
 
       if (nextStartTime) startTime = nextStartTime;
       if (stepInProgress) await apiClient.sleep(1000);
@@ -120,8 +121,8 @@ class DeployUtils {
       const alreadyLogged = stepsToSkip.includes(step.name);
 
       if (!alreadyLogged && step.status !== 'NOT_STARTED') {
-        console.log(`$$$ ${step.name}`);
-        console.log('#'.repeat(100));
+        logger.info(`$$$ ${step.name}`);
+        logger.info('#'.repeat(100));
         await this.writeDeploymentStepLog(deploymentLogId, step.name);
 
         doneSteps.push(step.name);
@@ -143,7 +144,7 @@ class DeployUtils {
 
       if (status !== 'IN_PROGRESS') {
         status === 'WAITING_FOR_USER' &&
-          console.log("Deployment is waiting for an approval. Run 'env0 approve' or 'env0 cancel' to continue.");
+          logger.info("Deployment is waiting for an approval. Run 'env0 approve' or 'env0 cancel' to continue.");
         return status;
       }
 
@@ -171,7 +172,7 @@ class DeployUtils {
       if (environmentValidStatuses.includes(status)) return;
       if (retryCount >= maxRetryNumber) throw new Error('Polling environment timed out');
 
-      console.log(`Waiting for environment to become deployable. (current status: ${status})`);
+      logger.info(`Waiting for environment to become deployable. (current status: ${status})`);
 
       retryCount++;
       await apiClient.sleep(5000);
@@ -185,7 +186,7 @@ class DeployUtils {
     await apiClient.callApi('put', envRoute, {
       data: { isArchived: true }
     });
-    console.log(`Environment ${environment.name} has been archived`);
+    logger.info(`Environment ${environment.name} has been archived`);
   }
 
   assertDeploymentStatus(status) {

--- a/node/src/lib/logger.js
+++ b/node/src/lib/logger.js
@@ -2,7 +2,7 @@ const { createLogger, format, transports } = require('winston');
 const _ = require('lodash');
 const { argumentsMap } = require('../config/arguments');
 
-const secrets = [];
+let secrets = [];
 
 const getSecureSecret = secret => {
   const charsToKeep = 5;
@@ -16,9 +16,10 @@ const setSecrets = options => {
     .keys()
     .value();
 
-  const secretValues = secretOptions.map(opt => options[opt]);
-
-  secrets.push(...secretValues);
+  secrets = _(secretOptions)
+    .map(opt => options[opt])
+    .compact()
+    .value();
 };
 
 const masker = format(info => {

--- a/node/src/lib/logger.js
+++ b/node/src/lib/logger.js
@@ -2,13 +2,9 @@ const { createLogger, format, transports } = require('winston');
 const _ = require('lodash');
 const { argumentsMap } = require('../config/arguments');
 
-let secrets = [];
+const SECURE_STRING = '**********';
 
-const getSecureSecret = secret => {
-  const charsToKeep = 5;
-  const pattern = new RegExp(`^.{1,${secret.length - charsToKeep}}`);
-  return secret.replace(pattern, sub => '*'.repeat(sub.length));
-};
+let secrets = [];
 
 const setSecrets = options => {
   secrets = _(argumentsMap)
@@ -23,7 +19,7 @@ const masker = format(info => {
   let message = _.cloneDeep(info.message);
 
   secrets.forEach(secret => {
-    if (message.includes(secret)) message = message.split(secret).join(getSecureSecret(secret));
+    if (message.includes(secret)) message = message.split(secret).join(SECURE_STRING);
   });
 
   info.message = message;

--- a/node/src/lib/logger.js
+++ b/node/src/lib/logger.js
@@ -22,7 +22,7 @@ const setSecrets = options => {
 };
 
 const masker = format(info => {
-  let message = info.message;
+  let message = _.cloneDeep(info.message);
 
   secrets.forEach(secret => {
     if (message.includes(secret)) message = _.replace(message, secret, getSecureSecret(secret));
@@ -35,6 +35,7 @@ const masker = format(info => {
 const logger = createLogger({
   format: format.combine(
     masker(),
+    format.splat(),
     format.printf(info => info.message)
   ),
   transports: [new transports.Console({ showLevel: false })]

--- a/node/src/lib/logger.js
+++ b/node/src/lib/logger.js
@@ -11,12 +11,9 @@ const getSecureSecret = secret => {
 };
 
 const setSecrets = options => {
-  const secretOptions = _(argumentsMap)
+  secrets = _(argumentsMap)
     .pickBy(({ secret }) => secret)
     .keys()
-    .value();
-
-  secrets = _(secretOptions)
     .map(opt => options[opt])
     .compact()
     .value();

--- a/node/src/lib/logger.js
+++ b/node/src/lib/logger.js
@@ -1,0 +1,48 @@
+const { createLogger, format, transports } = require('winston');
+const _ = require('lodash');
+const { argumentsMap } = require('../config/arguments');
+
+const secrets = [];
+
+const getSecureSecret = secret => {
+  const charsToKeep = 5;
+  const pattern = new RegExp(`^.{1,${secret.length - charsToKeep}}`);
+  return secret.replace(pattern, sub => '*'.repeat(sub.length));
+};
+
+const setSecrets = options => {
+  const secretOptions = _(argumentsMap)
+    .pickBy(({ secret }) => secret)
+    .keys()
+    .value();
+
+  const secretValues = secretOptions.map(opt => options[opt]);
+
+  secrets.push(...secretValues);
+};
+
+const masker = format(info => {
+  let message = info.message;
+
+  secrets.forEach(secret => {
+    if (message.includes(secret)) {
+      const secureSecret = getSecureSecret(secret);
+      message = _.replace(message, secret, secureSecret);
+    }
+  });
+
+  info.message = message;
+  return info;
+});
+
+const logger = createLogger({
+  format: format.combine(
+    masker(),
+    format.printf(info => info.message)
+  ),
+  transports: [new transports.Console({ showLevel: false })]
+});
+
+logger.setSecrets = setSecrets;
+
+module.exports = logger;

--- a/node/src/lib/logger.js
+++ b/node/src/lib/logger.js
@@ -26,7 +26,7 @@ const masker = format(info => {
   let message = _.cloneDeep(info.message);
 
   secrets.forEach(secret => {
-    if (message.includes(secret)) message = _.replace(message, secret, getSecureSecret(secret));
+    if (message.includes(secret)) message = message.split(secret).join(getSecureSecret(secret));
   });
 
   info.message = message;

--- a/node/src/lib/logger.js
+++ b/node/src/lib/logger.js
@@ -25,10 +25,7 @@ const masker = format(info => {
   let message = info.message;
 
   secrets.forEach(secret => {
-    if (message.includes(secret)) {
-      const secureSecret = getSecureSecret(secret);
-      message = _.replace(message, secret, secureSecret);
-    }
+    if (message.includes(secret)) message = _.replace(message, secret, getSecureSecret(secret));
   });
 
   info.message = message;

--- a/node/src/main.js
+++ b/node/src/main.js
@@ -4,6 +4,7 @@ const { options } = require('./config/constants');
 const { commands } = require('./config/commands');
 const { version } = require('../package.json');
 const help = require('./commands/help');
+const logger = require('./lib/logger');
 
 const mainDefinitions = [{ name: 'command', defaultOption: true }];
 
@@ -27,7 +28,7 @@ const isInternalCommand = async (command, args) => {
   }
 
   if (['--version'].some(h => args.includes(h)) || command === 'version') {
-    console.log(version);
+    logger.info(version);
     isInternalCmd = true;
   }
 
@@ -47,6 +48,7 @@ const run = async () => {
 
     const commandDefinitions = commands[command].options;
     const commandOptions = commandLineArgs(commandDefinitions, { argv });
+
     const environmentVariables = getEnvironmentVariablesOptions(
       commandOptions[ENVIRONMENT_VARIABLES],
       commandOptions[SENSITIVE_ENVIRONMENT_VARIABLES]
@@ -54,13 +56,13 @@ const run = async () => {
 
     await runCommand(command, commandOptions, environmentVariables);
   } catch (error) {
-    console.error(`Command ${command} has failed. Error:`);
+    logger.error(`Command ${command} has failed. Error:`);
     let { message } = error;
     if (error.response && error.response.data && error.response.data.message) {
       message += `: ${error.response.data.message}`;
     }
 
-    console.error(message);
+    logger.error(message);
     process.exit(1);
   }
 };
@@ -69,7 +71,7 @@ const parseEnvironmentVariables = (environmentVariables, sensitive) => {
   const result = [];
 
   if (environmentVariables && environmentVariables.length > 0) {
-    console.log(`Getting ${sensitive ? 'Sensitive ' : ''}Environment Variables from options:`, environmentVariables);
+    logger.info(`Getting ${sensitive ? 'Sensitive ' : ''}Environment Variables from options:`, environmentVariables);
 
     environmentVariables.forEach(config => {
       let [name, ...value] = config.split('=');

--- a/node/tests/lib/logger.spec.js
+++ b/node/tests/lib/logger.spec.js
@@ -16,9 +16,9 @@ describe('logger', () => {
   `('should hide $option', ({ option }) => {
     logger.setSecrets({ [option]: mockSecret });
 
-    logger.info(`${option}: ${mockSecret}`);
+    logger.info(`${option}: ${mockSecret} ${option}: ${mockSecret}`);
 
-    expect(console.log).toBeCalledWith(`${option}: ${secureMockSecret}`);
+    expect(console.log).toBeCalledWith(`${option}: ${secureMockSecret} ${option}: ${secureMockSecret}`);
   });
 
   it.each`

--- a/node/tests/lib/logger.spec.js
+++ b/node/tests/lib/logger.spec.js
@@ -5,8 +5,8 @@ global.console = {
   log: jest.fn()
 };
 
-const mockSecret = 'AAAAABBBBBCCCCCDDDDD';
-const secureMockSecret = '***************DDDDD';
+const mockSecret = 'TopSecret';
+const secureSecret = '**********';
 
 describe('logger', () => {
   it.each`
@@ -18,7 +18,7 @@ describe('logger', () => {
 
     logger.info(`${option}: ${mockSecret} ${option}: ${mockSecret}`);
 
-    expect(console.log).toBeCalledWith(`${option}: ${secureMockSecret} ${option}: ${secureMockSecret}`);
+    expect(console.log).toBeCalledWith(`${option}: ${secureSecret} ${option}: ${secureSecret}`);
   });
 
   it.each`

--- a/node/tests/lib/logger.spec.js
+++ b/node/tests/lib/logger.spec.js
@@ -1,0 +1,37 @@
+const logger = require('../../src/lib/logger');
+const { options } = require('../../src/config/constants');
+
+global.console = {
+  log: jest.fn()
+};
+
+const mockSecret = 'AAAAABBBBBCCCCCDDDDD';
+const secureMockSecret = '***************DDDDD';
+
+describe('logger', () => {
+  it.each`
+    option
+    ${options.API_KEY}
+    ${options.API_SECRET}
+  `('should hide $option', ({ option }) => {
+    logger.setSecrets({ [option]: mockSecret });
+
+    logger.info(`${option}: ${mockSecret}`);
+
+    expect(console.log).toBeCalledWith(`${option}: ${secureMockSecret}`);
+  });
+
+  it.each`
+    option
+    ${options.ENVIRONMENT_NAME}
+    ${options.PROJECT_ID}
+    ${options.ORGANIZATION_ID}
+    ${options.BLUEPRINT_ID}
+  `('should not hide $option', ({ option }) => {
+    logger.setSecrets({ [option]: mockSecret });
+
+    logger.info(`${option}: ${mockSecret}`);
+
+    expect(console.log).toBeCalledWith(`${option}: ${mockSecret}`);
+  });
+});

--- a/node/tests/main.spec.js
+++ b/node/tests/main.spec.js
@@ -3,7 +3,9 @@ const run = require('../src/main');
 const commandLineArgs = require('command-line-args');
 const commandLineUsage = require('command-line-usage');
 const { version } = require('../package.json');
+const logger = require('../src/lib/logger');
 
+jest.mock('../src/lib/logger');
 jest.mock('../src/commands/run-command');
 jest.mock('command-line-usage');
 jest.mock('command-line-args');
@@ -68,12 +70,11 @@ describe('main', () => {
       ${'version'}
     `('when user asks to see the version with $command', ({ command }) => {
       beforeEach(async () => {
-        jest.spyOn(console, 'log');
         await mockOptionsAndRun({ command, rawArgs: [command] });
       });
 
       it('should show the proper version', () => {
-        expect(console.log).toBeCalledWith(version);
+        expect(logger.info).toBeCalledWith(version);
       });
     });
 

--- a/node/tests/main.spec.js
+++ b/node/tests/main.spec.js
@@ -30,8 +30,6 @@ const mockOptionsAndRun = async ({ command, rawArgs, args }) => {
 describe('main', () => {
   beforeEach(() => {
     jest.spyOn(process, 'exit').mockReturnValue({});
-    jest.spyOn(console, 'log').mockReturnValue({});
-    jest.spyOn(console, 'error').mockReturnValue({});
   });
 
   describe("when command doesn't exist", () => {
@@ -44,7 +42,7 @@ describe('main', () => {
     });
 
     it('should print to stderr', () => {
-      expect(console.error).toBeCalled();
+      expect(logger.error).toBeCalled();
     });
     it('should exit with 1', () => {
       expect(process.exit).toBeCalledWith(1);
@@ -83,8 +81,9 @@ describe('main', () => {
           await mockOptionsAndRun({ command, rawArgs: [command] });
         });
 
-      it('should show the proper version', () => {
-        expect(logger.info).toBeCalledWith(version);
+        it('should show the proper version', () => {
+          expect(logger.info).toBeCalledWith(version);
+        });
       });
     });
 

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -139,6 +139,15 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@dabh/diagnostics@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@dabh/diagnostics/-/diagnostics-2.0.2.tgz#290d08f7b381b8f94607dc8f471a12c675f9db31"
+  integrity sha512-+A1YivoVDNNVCdfozHSR8v/jyuuLTMXwjWuxPFlFlUapXoGc+Gj9mDlTDDfrwl7rXCl2tNZ0kE8sIBO6YOn96Q==
+  dependencies:
+    colorspace "1.1.x"
+    enabled "2.0.x"
+    kuler "^2.0.0"
+
 "@jest/console@^24.7.1", "@jest/console@^24.9.0":
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.9.0.tgz#79b1bc06fb74a8cfb01cbdedf945584b1b9707f0"
@@ -536,6 +545,11 @@ async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.1.tgz#dd379e94f0db8310b08291f9d64c3209766617fd"
   integrity sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ==
 
+async@^3.1.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.0.tgz#b3a2685c5ebb641d3de02d161002c60fc9f85720"
+  integrity sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -814,7 +828,7 @@ collection-visit@^1.0.0:
     map-visit "^1.0.0"
     object-visit "^1.0.0"
 
-color-convert@^1.9.0:
+color-convert@^1.9.0, color-convert@^1.9.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-1.9.3.tgz#bb71850690e1f136567de629d2d5471deda4c1e8"
   integrity sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
@@ -833,10 +847,39 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
 
-color-name@~1.1.4:
+color-name@^1.0.0, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-string@^1.5.2:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.5.3.tgz#c9bbc5f01b58b5492f3d6857459cb6590ce204cc"
+  integrity sha512-dC2C5qeWoYkxki5UAXapdjqO672AM4vZuPGRQfO8b5HKuKGBbKWpITyDYN7TOFKvRW7kOgAn3746clDBMDJyQw==
+  dependencies:
+    color-name "^1.0.0"
+    simple-swizzle "^0.2.2"
+
+color@3.0.x:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/color/-/color-3.0.0.tgz#d920b4328d534a3ac8295d68f7bd4ba6c427be9a"
+  integrity sha512-jCpd5+s0s0t7p3pHQKpnJ0TpQKKdleP71LWcA0aqiljpiuAkOSUFN/dyH8ZwF0hRmFlrIuRhufds1QyEP9EB+w==
+  dependencies:
+    color-convert "^1.9.1"
+    color-string "^1.5.2"
+
+colors@^1.2.1:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
+
+colorspace@1.1.x:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/colorspace/-/colorspace-1.1.2.tgz#e0128950d082b86a2168580796a0aa5d6c68d8c5"
+  integrity sha512-vt+OoIP2d76xLhjwbBaucYlNSpPsrJWPlBTtwCpQKIu6/CSMutyzX93O/Do0qzpH3YoHEes8YEFXyZ797rEhzQ==
+  dependencies:
+    color "3.0.x"
+    text-hex "1.0.x"
 
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"
@@ -887,7 +930,7 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-core-util-is@1.0.2:
+core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
@@ -1047,6 +1090,11 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
+enabled@2.0.x:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/enabled/-/enabled-2.0.0.tgz#f9dd92ec2d6f4bbc0d5d1e64e21d61cd4665e7c2"
+  integrity sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==
 
 end-of-stream@^1.1.0:
   version "1.4.4"
@@ -1346,12 +1394,22 @@ fast-levenshtein@~2.0.6:
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
+fast-safe-stringify@^2.0.4:
+  version "2.0.7"
+  resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
+  integrity sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA==
+
 fb-watchman@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fb-watchman/-/fb-watchman-2.0.1.tgz#fc84fb39d2709cf3ff6d743706157bb5708a8a85"
   integrity sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==
   dependencies:
     bser "2.1.1"
+
+fecha@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.0.tgz#3ffb6395453e3f3efff850404f0a59b6747f5f41"
+  integrity sha512-aN3pcx/DSmtyoovUudctc8+6Hl4T+hI9GBBHLjA76jdZl7+b1sgh5g4k+u/GL3dTy1/pnYzKp69FpJ0OicE3Wg==
 
 figures@^3.0.0:
   version "3.1.0"
@@ -1409,6 +1467,11 @@ flatted@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
+
+fn.name@1.x.x:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
+  integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
 follow-redirects@1.5.10:
   version "1.5.10"
@@ -1689,7 +1752,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2:
+inherits@2, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -1738,6 +1801,11 @@ is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
+
+is-arrayish@^0.3.1:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.2.tgz#4574a2ae56f7ab206896fb431eaeed066fdf8f03"
+  integrity sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==
 
 is-buffer@^1.1.5:
   version "1.1.6"
@@ -1868,6 +1936,11 @@ is-stream@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
 
+is-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
+  integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
+
 is-symbol@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.3.tgz#38e1014b9e6329be0de9d24a414fd7441ec61937"
@@ -1890,7 +1963,7 @@ is-wsl@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
-isarray@1.0.0:
+isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
   integrity sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
@@ -2451,6 +2524,11 @@ kleur@^3.0.3:
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-3.0.3.tgz#a79c9ecc86ee1ce3fa6206d1216c501f147fc07e"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
+kuler@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/kuler/-/kuler-2.0.0.tgz#e2c570a3800388fb44407e851531c1d670b061b3"
+  integrity sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==
+
 left-pad@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.3.0.tgz#5b8a3a7765dfe001261dde915589e782f8c94d1e"
@@ -2501,6 +2579,17 @@ lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+
+logform@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/logform/-/logform-2.2.0.tgz#40f036d19161fc76b68ab50fdc7fe495544492f2"
+  integrity sha512-N0qPlqfypFx7UHNn4B3lzS/b0uLqt2hmuoa+PpuXNYgozdJYAyauF5Ky0BWVjrxDlMWiT3qN4zPq3vVAfZy7Yg==
+  dependencies:
+    colors "^1.2.1"
+    fast-safe-stringify "^2.0.4"
+    fecha "^4.2.0"
+    ms "^2.1.1"
+    triple-beam "^1.3.0"
 
 loose-envify@^1.0.0:
   version "1.4.0"
@@ -2769,6 +2858,13 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
+one-time@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/one-time/-/one-time-1.0.0.tgz#e06bc174aed214ed58edede573b433bbf827cb45"
+  integrity sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==
+  dependencies:
+    fn.name "1.x.x"
+
 onetime@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.0.tgz#fff0f3c91617fe62bb50189636e99ac8a6df7be5"
@@ -2947,6 +3043,11 @@ pretty-format@^24.9.0:
     ansi-styles "^3.2.0"
     react-is "^16.8.4"
 
+process-nextick-args@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
+  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+
 progress@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
@@ -3009,6 +3110,28 @@ read-pkg@^3.0.0:
     load-json-file "^4.0.0"
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
+
+readable-stream@^2.3.7:
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
+  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
+
+readable-stream@^3.4.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
+  integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
 
 realpath-native@^1.1.0:
   version "1.1.0"
@@ -3187,10 +3310,15 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.2:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
   integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
 
-safe-buffer@~5.1.1:
+safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+
+safe-buffer@~5.2.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 safe-regex@^1.1.0:
   version "1.1.0"
@@ -3270,6 +3398,13 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
+
+simple-swizzle@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.2.tgz#a4da6b635ffcccca33f70d17cb92592de95e557a"
+  integrity sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=
+  dependencies:
+    is-arrayish "^0.3.1"
 
 sisteransi@^1.0.3:
   version "1.0.4"
@@ -3407,6 +3542,11 @@ sshpk@^1.7.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
+stack-trace@0.0.x:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
+  integrity sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=
+
 stack-utils@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
@@ -3466,6 +3606,20 @@ string.prototype.trimright@^2.1.1:
   dependencies:
     define-properties "^1.1.3"
     function-bind "^1.1.1"
+
+string_decoder@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
+  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+  dependencies:
+    safe-buffer "~5.2.0"
+
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+  dependencies:
+    safe-buffer "~5.1.0"
 
 strip-ansi@^4.0.0:
   version "4.0.0"
@@ -3564,6 +3718,11 @@ test-exclude@^5.2.3:
     read-pkg-up "^4.0.0"
     require-main-filename "^2.0.0"
 
+text-hex@1.0.x:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/text-hex/-/text-hex-1.0.0.tgz#69dc9c1b17446ee79a92bf5b884bb4b9127506f5"
+  integrity sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==
+
 text-table@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
@@ -3644,6 +3803,11 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
+triple-beam@^1.2.0, triple-beam@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/triple-beam/-/triple-beam-1.3.0.tgz#a595214c7298db8339eeeee083e4d10bd8cb8dd9"
+  integrity sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==
+
 tslib@^1.9.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
@@ -3722,6 +3886,11 @@ use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
+
+util-deprecate@^1.0.1, util-deprecate@~1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
 
 util.promisify@^1.0.0:
   version "1.0.0"
@@ -3825,6 +3994,29 @@ widest-line@^3.1.0:
   integrity sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==
   dependencies:
     string-width "^4.0.0"
+
+winston-transport@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.4.0.tgz#17af518daa690d5b2ecccaa7acf7b20ca7925e59"
+  integrity sha512-Lc7/p3GtqtqPBYYtS6KCN3c77/2QCev51DvcJKbkFPQNoj1sinkGwLGFDxkXY9J6p9+EPnYs+D90uwbnaiURTw==
+  dependencies:
+    readable-stream "^2.3.7"
+    triple-beam "^1.2.0"
+
+winston@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-3.3.3.tgz#ae6172042cafb29786afa3d09c8ff833ab7c9170"
+  integrity sha512-oEXTISQnC8VlSAKf1KYSSd7J6IWuRPQqDdo8eoRNaYKLvwSb5+79Z3Yi1lrl6KDpU6/VWaxpakDAtb1oQ4n9aw==
+  dependencies:
+    "@dabh/diagnostics" "^2.0.2"
+    async "^3.1.0"
+    is-stream "^2.0.0"
+    logform "^2.2.0"
+    one-time "^1.0.0"
+    readable-stream "^3.4.0"
+    stack-trace "0.0.x"
+    triple-beam "^1.3.0"
+    winston-transport "^4.4.0"
 
 word-wrap@~1.2.3:
   version "1.2.3"


### PR DESCRIPTION
### Feature Request
We shouldn't log secrets.

### Solution
1. Add a `winston` with a custom formatter that masks secrets like: `this-is-top-secret` -> `***************ecret`
2. Replace all `console` usage to use `logger` instead.

