### PR TITLE
Fix: final qa rejects

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -97,10 +97,6 @@ For sensitive environment variables, use:
 - Usage: `--revision`
 - Alias: `-r`
 
-### Archive After Destroy
-> Archives the environment after a successful destroy
-- Usage: `--archiveAfterDestroy`
-
 ### Requires Approval
 > Requires approval for deployment. Valid values are either "true" or "false".
 - Usage: `--requiresApproval <true/false>`

--- a/node/README.md
+++ b/node/README.md
@@ -89,7 +89,7 @@ For sensitive environment variables, use:
 - Alias: `-q`
 
 ### Revision
-> Your GIT revision, can be a branch, a tag or a commit hash. Defaults to `master`
+> Your GIT revision, can be a branch, a tag or a commit hash. (For existing environments - if not specified, will use the previously defined revision)
 - Usage: `--revision`
 - Alias: `-r`
 

--- a/node/README.md
+++ b/node/README.md
@@ -102,8 +102,8 @@ For sensitive environment variables, use:
 - Usage: `--archiveAfterDestroy`
 
 ### Requires Approval
-> Requires approval for deployment
-- Usage: `--requiresApproval`
+> Requires approval for deployment. Valid values are either "true" or "false".
+- Usage: `--requiresApproval <true/false>`
 - Alias: `-a`
 
 ## Configuration File

--- a/node/jest.config.js
+++ b/node/jest.config.js
@@ -2,5 +2,6 @@ module.exports = {
   testEnvironment: 'node',
   resetMocks: true,
   clearMocks: true,
-  modulePaths: ['node_modules', '.']
+  modulePaths: ['node_modules', '.'],
+  setupFilesAfterEnv: ['jest-extended']
 };

--- a/node/package.json
+++ b/node/package.json
@@ -45,6 +45,7 @@
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",
     "jest": "^24.9.0",
+    "jest-extended": "^0.11.5",
     "prettier": "^2.0.5"
   }
 }

--- a/node/src/commands/cancel.js
+++ b/node/src/commands/cancel.js
@@ -1,3 +1,3 @@
 const setDeploymentStatusApproval = require('../lib/set-deployment-approval-status');
 
-module.exports = setDeploymentStatusApproval('cancel');
+module.exports = setDeploymentStatusApproval('cancel', false);

--- a/node/src/commands/configure.js
+++ b/node/src/commands/configure.js
@@ -1,6 +1,7 @@
 const inquirer = require('inquirer');
 const configManager = require('../lib/config-manager');
 const { argumentsMap } = require('../config/arguments');
+const _ = require('lodash');
 
 const emptyConfig = configManager.INCLUDED_OPTIONS.reduce((acc, key) => {
   acc[key] = '';
@@ -16,6 +17,8 @@ const getQuestions = configuration => {
   }));
 };
 
+const removeEmptyAnswers = answers => _.pickBy(answers, i => i);
+
 const configure = async () => {
   const configuration = { ...emptyConfig, ...configManager.read() };
 
@@ -23,7 +26,7 @@ const configure = async () => {
 
   const answers = await inquirer.prompt(questions);
 
-  configManager.write(answers);
+  configManager.write(removeEmptyAnswers(answers));
 };
 
 module.exports = configure;

--- a/node/src/commands/deploy.js
+++ b/node/src/commands/deploy.js
@@ -1,5 +1,6 @@
 const DeployUtils = require('../lib/deploy-utils');
 const logger = require('../lib/logger');
+const { convertRequiresApprovalToBoolean } = require('../lib/genetal-utils');
 
 const setConfigurationFromOptions = async (environmentVariables, environment, blueprintId) => {
   const deployUtils = new DeployUtils();
@@ -28,7 +29,12 @@ const deploy = async (options, environmentVariables) => {
 
   await setConfigurationFromOptions(environmentVariables, environment, blueprintId);
 
-  const deployment = await deployUtils.deployEnvironment(environment, revision, blueprintId, requiresApproval);
+  const deployment = await deployUtils.deployEnvironment(
+    environment,
+    revision,
+    blueprintId,
+    convertRequiresApprovalToBoolean(requiresApproval)
+  );
   const status = await deployUtils.pollDeploymentStatus(deployment.id);
 
   deployUtils.assertDeploymentStatus(status);

--- a/node/src/commands/deploy.js
+++ b/node/src/commands/deploy.js
@@ -19,7 +19,7 @@ const deploy = async (options, environmentVariables) => {
 
   const { environmentName, projectId, organizationId, blueprintId, revision, requiresApproval } = options;
 
-  console.log('Waiting for deployment to start...');
+  logger.info('Waiting for deployment to start...');
   let environment = await deployUtils.getEnvironment(environmentName, projectId);
 
   if (!environment) {

--- a/node/src/commands/deploy.js
+++ b/node/src/commands/deploy.js
@@ -18,6 +18,7 @@ const deploy = async (options, environmentVariables) => {
 
   const { environmentName, projectId, organizationId, blueprintId, revision, requiresApproval } = options;
 
+  console.log('Waiting for deployment to start...');
   let environment = await deployUtils.getEnvironment(environmentName, projectId);
 
   if (!environment) {

--- a/node/src/commands/destroy.js
+++ b/node/src/commands/destroy.js
@@ -3,6 +3,7 @@ const DeployUtils = require('../lib/deploy-utils');
 const destroy = async options => {
   const deployUtils = new DeployUtils();
 
+  console.log('Waiting for deployment to start...');
   const environment = await deployUtils.getEnvironment(options.environmentName, options.projectId);
   let status;
 

--- a/node/src/commands/destroy.js
+++ b/node/src/commands/destroy.js
@@ -1,20 +1,32 @@
 const DeployUtils = require('../lib/deploy-utils');
+const { options } = require('../config/constants');
+const _ = require('lodash');
+
+const { PROJECT_ID, ENVIRONMENT_NAME, REQUIRES_APPROVAL, ARCHIVE_AFTER_DESTROY } = options;
+
+const assertEnvironmentExists = environment => {
+  if (!environment) {
+    throw new Error(`Could not find an environment with the name ${options[ENVIRONMENT_NAME]}`);
+  }
+};
 
 const destroy = async options => {
   const deployUtils = new DeployUtils();
 
   console.log('Waiting for deployment to start...');
-  const environment = await deployUtils.getEnvironment(options.environmentName, options.projectId);
+  const environment = await deployUtils.getEnvironment(options[ENVIRONMENT_NAME], options[PROJECT_ID]);
   let status;
 
-  if (environment) {
-    const deployment = await deployUtils.destroyEnvironment(environment);
-    status = await deployUtils.pollDeploymentStatus(deployment.id);
+  assertEnvironmentExists(environment);
 
-    if (options.archiveAfterDestroy) await deployUtils.archiveIfInactive(environment.id);
-  } else {
-    throw new Error(`Could not find an environment with the name ${options.environmentName}`);
+  if (!_.isUndefined(options[REQUIRES_APPROVAL]) && options[REQUIRES_APPROVAL] !== environment.requiresApproval) {
+    await deployUtils.updateEnvironment(environment, { requiresApproval: options[REQUIRES_APPROVAL] });
   }
+
+  const deployment = await deployUtils.destroyEnvironment(environment);
+  status = await deployUtils.pollDeploymentStatus(deployment.id);
+
+  if (options[ARCHIVE_AFTER_DESTROY]) await deployUtils.archiveIfInactive(environment.id);
 
   deployUtils.assertDeploymentStatus(status);
 };

--- a/node/src/commands/destroy.js
+++ b/node/src/commands/destroy.js
@@ -2,6 +2,7 @@ const DeployUtils = require('../lib/deploy-utils');
 const { options } = require('../config/constants');
 const _ = require('lodash');
 const logger = require('../lib/logger');
+const { convertRequiresApprovalToBoolean } = require('../lib/genetal-utils');
 
 const { PROJECT_ID, ENVIRONMENT_NAME, REQUIRES_APPROVAL, ARCHIVE_AFTER_DESTROY } = options;
 
@@ -20,7 +21,7 @@ const destroy = async options => {
 
   assertEnvironmentExists(environment);
 
-  const requiresApproval = eval(options[REQUIRES_APPROVAL]);
+  const requiresApproval = convertRequiresApprovalToBoolean(options[REQUIRES_APPROVAL]);
 
   if (!_.isUndefined(requiresApproval) && requiresApproval !== environment.requiresApproval) {
     await deployUtils.updateEnvironment(environment, { requiresApproval: requiresApproval });

--- a/node/src/commands/destroy.js
+++ b/node/src/commands/destroy.js
@@ -1,6 +1,7 @@
 const DeployUtils = require('../lib/deploy-utils');
 const { options } = require('../config/constants');
 const _ = require('lodash');
+const logger = require('../lib/logger');
 
 const { PROJECT_ID, ENVIRONMENT_NAME, REQUIRES_APPROVAL, ARCHIVE_AFTER_DESTROY } = options;
 
@@ -13,7 +14,7 @@ const assertEnvironmentExists = environment => {
 const destroy = async options => {
   const deployUtils = new DeployUtils();
 
-  console.log('Waiting for deployment to start...');
+  logger.info('Waiting for deployment to start...');
   const environment = await deployUtils.getEnvironment(options[ENVIRONMENT_NAME], options[PROJECT_ID]);
   let status;
 

--- a/node/src/commands/destroy.js
+++ b/node/src/commands/destroy.js
@@ -4,7 +4,7 @@ const _ = require('lodash');
 const logger = require('../lib/logger');
 const { convertRequiresApprovalToBoolean } = require('../lib/genetal-utils');
 
-const { PROJECT_ID, ENVIRONMENT_NAME, REQUIRES_APPROVAL, ARCHIVE_AFTER_DESTROY } = options;
+const { PROJECT_ID, ENVIRONMENT_NAME, REQUIRES_APPROVAL } = options;
 
 const assertEnvironmentExists = environment => {
   if (!environment) {
@@ -29,8 +29,6 @@ const destroy = async options => {
 
   const deployment = await deployUtils.destroyEnvironment(environment);
   status = await deployUtils.pollDeploymentStatus(deployment.id);
-
-  if (options[ARCHIVE_AFTER_DESTROY]) await deployUtils.archiveIfInactive(environment.id);
 
   deployUtils.assertDeploymentStatus(status);
 };

--- a/node/src/commands/destroy.js
+++ b/node/src/commands/destroy.js
@@ -20,8 +20,10 @@ const destroy = async options => {
 
   assertEnvironmentExists(environment);
 
-  if (!_.isUndefined(options[REQUIRES_APPROVAL]) && options[REQUIRES_APPROVAL] !== environment.requiresApproval) {
-    await deployUtils.updateEnvironment(environment, { requiresApproval: options[REQUIRES_APPROVAL] });
+  const requiresApproval = eval(options[REQUIRES_APPROVAL]);
+
+  if (!_.isUndefined(requiresApproval) && requiresApproval !== environment.requiresApproval) {
+    await deployUtils.updateEnvironment(environment, { requiresApproval: requiresApproval });
   }
 
   const deployment = await deployUtils.destroyEnvironment(environment);

--- a/node/src/commands/help.js
+++ b/node/src/commands/help.js
@@ -26,7 +26,7 @@ const sections = [
   {
     header: 'Usage',
     content: [
-      `$ env0 deploy -k <${API_KEY}> -s <${API_SECRET}> -o <${ORGANIZATION_ID}> -p <${PROJECT_ID}> -b <${BLUEPRINT_ID}> -e <${ENVIRONMENT_NAME}> -r [master] -v [stage=dev]`,
+      `$ env0 deploy -k <${API_KEY}> -s <${API_SECRET}> -o <${ORGANIZATION_ID}> -p <${PROJECT_ID}> -b <${BLUEPRINT_ID}> -e <${ENVIRONMENT_NAME}> -r <revision> -v [stage=dev]`,
       '$ env0 --help'
     ]
   },

--- a/node/src/commands/help.js
+++ b/node/src/commands/help.js
@@ -26,7 +26,7 @@ const sections = [
   {
     header: 'Usage',
     content: [
-      `$ env0 deploy -k <${API_KEY}> -s <${API_SECRET}> -o <${ORGANIZATION_ID}> -p <${PROJECT_ID}> -b <${BLUEPRINT_ID}> -e <${ENVIRONMENT_NAME}> -r <revision> -v [stage=dev]`,
+      `$ env0 deploy -k <${API_KEY}> -s <${API_SECRET}> -o <${ORGANIZATION_ID}> -p <${PROJECT_ID}> -b <${BLUEPRINT_ID}> -e <${ENVIRONMENT_NAME}> -r [revision] -v [stage=dev]`,
       '$ env0 --help'
     ]
   },

--- a/node/src/commands/run-command.js
+++ b/node/src/commands/run-command.js
@@ -6,8 +6,10 @@ const approve = require('./approve');
 const cancel = require('./cancel');
 const { options } = require('../config/constants');
 const logger = require('../lib/logger');
+const _ = require('lodash');
+const { argumentsMap } = require('../config/arguments');
 
-const { API_KEY, API_SECRET, ORGANIZATION_ID, PROJECT_ID, ENVIRONMENT_NAME } = options;
+const { API_KEY, API_SECRET, ORGANIZATION_ID, PROJECT_ID, ENVIRONMENT_NAME, REQUIRES_APPROVAL } = options;
 
 const assertRequiredOptions = options => {
   const requiredOptions = [API_KEY, API_SECRET, ORGANIZATION_ID, PROJECT_ID, ENVIRONMENT_NAME];
@@ -20,9 +22,21 @@ const assertRequiredOptions = options => {
   }
 };
 
+const assertRequiresApprovalOption = requiresApproval => {
+  const validValues = ['true', 'false'];
+
+  if (!_.isUndefined(requiresApproval) && !validValues.includes(requiresApproval)) {
+    throw Error(
+      `Bad argument received. --${REQUIRES_APPROVAL} (-${argumentsMap[REQUIRES_APPROVAL].alias}) can be either "true" or "false".`
+    );
+  }
+};
+
 const runCommand = async (command, options, environmentVariables) => {
   options = configManager.read(options);
   assertRequiredOptions(options);
+  assertRequiresApprovalOption(options[REQUIRES_APPROVAL]);
+
   configManager.write(options);
 
   logger.setSecrets(options);

--- a/node/src/commands/run-command.js
+++ b/node/src/commands/run-command.js
@@ -36,7 +36,6 @@ const runCommand = async (command, options, environmentVariables) => {
 
   await DeployUtils.init(options);
 
-  console.log('Waiting for deployment to start...');
   await commands[command](options, environmentVariables);
   console.log(`Command ${command} has finished successfully.`);
 };

--- a/node/src/config/arguments.js
+++ b/node/src/config/arguments.js
@@ -56,9 +56,9 @@ const argumentsMap = {
   [REQUIRES_APPROVAL]: {
     name: REQUIRES_APPROVAL,
     alias: 'a',
-    type: Boolean,
-    defaultValue: false,
-    description: 'Whether deployment should wait for approval on plan stage before deploying your environment'
+    type: String,
+    description:
+      'Whether deployment should wait for approval on plan stage before deploying your environment. Can be either "true" or "false"'
   },
   [ENVIRONMENT_VARIABLES]: {
     name: ENVIRONMENT_VARIABLES,

--- a/node/src/config/arguments.js
+++ b/node/src/config/arguments.js
@@ -74,7 +74,6 @@ const argumentsMap = {
     name: REVISION,
     alias: 'r',
     type: String,
-    defaultValue: 'master',
     description: 'Your git revision, can be a branch tag or a commit hash. Default value "master" '
   },
   [ARCHIVE_AFTER_DESTROY]: {

--- a/node/src/config/arguments.js
+++ b/node/src/config/arguments.js
@@ -10,7 +10,6 @@ const {
   ENVIRONMENT_VARIABLES,
   SENSITIVE_ENVIRONMENT_VARIABLES,
   REVISION,
-  ARCHIVE_AFTER_DESTROY,
   REQUIRES_APPROVAL
 } = options;
 
@@ -83,12 +82,6 @@ const argumentsMap = {
     alias: 'r',
     type: String,
     description: 'Your git revision, can be a branch tag or a commit hash. Default value "master" '
-  },
-  [ARCHIVE_AFTER_DESTROY]: {
-    name: ARCHIVE_AFTER_DESTROY,
-    type: Boolean,
-    defaultValue: false,
-    description: 'Archive the environment after a successful destroy'
   }
 };
 

--- a/node/src/config/constants.js
+++ b/node/src/config/constants.js
@@ -8,7 +8,6 @@ const options = {
   ENVIRONMENT_VARIABLES: 'environmentVariables',
   SENSITIVE_ENVIRONMENT_VARIABLES: 'sensitiveEnvironmentVariables',
   REVISION: 'revision',
-  ARCHIVE_AFTER_DESTROY: 'archiveAfterDestroy',
   REQUIRES_APPROVAL: 'requiresApproval'
 };
 

--- a/node/src/lib/deploy-utils.js
+++ b/node/src/lib/deploy-utils.js
@@ -193,16 +193,6 @@ class DeployUtils {
     } while (!environmentValidStatuses.includes(status));
   }
 
-  async archiveIfInactive(environmentId) {
-    const envRoute = `environments/${environmentId}`;
-    const environment = await apiClient.callApi('get', envRoute);
-    if (environment.status !== 'INACTIVE') throw new Error('Environment did not reach INACTIVE status');
-    await apiClient.callApi('put', envRoute, {
-      data: { isArchived: true }
-    });
-    logger.info(`Environment ${environment.name} has been archived`);
-  }
-
   assertDeploymentStatus(status) {
     if (!['SUCCESS', 'WAITING_FOR_USER', 'CANCELLED'].includes(status)) {
       throw new Error(`Deployment failed. Current deployment status is ${status}`);

--- a/node/src/lib/deploy-utils.js
+++ b/node/src/lib/deploy-utils.js
@@ -131,7 +131,7 @@ class DeployUtils {
     return doneSteps;
   }
 
-  async pollDeploymentStatus(deploymentLogId) {
+  async pollDeploymentStatus(deploymentLogId, shouldProcessDeploymentSteps) {
     const MAX_TIME_IN_SECONDS = 10800; // 3 hours
     const start = Date.now();
     const stepsAlreadyLogged = [];
@@ -139,7 +139,9 @@ class DeployUtils {
     while (true) {
       const { status } = await apiClient.callApi('get', `environments/deployments/${deploymentLogId}`);
 
-      stepsAlreadyLogged.push(...(await this.processDeploymentSteps(deploymentLogId, stepsAlreadyLogged)));
+      if (shouldProcessDeploymentSteps) {
+        stepsAlreadyLogged.push(...(await this.processDeploymentSteps(deploymentLogId, stepsAlreadyLogged)));
+      }
 
       if (status !== 'IN_PROGRESS') {
         status === 'WAITING_FOR_USER' &&

--- a/node/src/lib/deploy-utils.js
+++ b/node/src/lib/deploy-utils.js
@@ -1,6 +1,9 @@
 const Env0ApiClient = require('./api-client');
 const logger = require('./logger');
 const _ = require('lodash');
+const { options } = require('../config/constants');
+
+const { API_KEY, API_SECRET } = options;
 
 const apiClient = new Env0ApiClient();
 
@@ -8,7 +11,7 @@ const removeEmptyValues = payload => _.omitBy(payload, _.isUndefined);
 
 class DeployUtils {
   static async init(options) {
-    await apiClient.init(options.apiKey, options.apiSecret);
+    await apiClient.init(options[API_KEY], options[API_SECRET]);
   }
 
   async getEnvironment(environmentName, projectId) {
@@ -80,14 +83,14 @@ class DeployUtils {
   async deployEnvironment(environment, blueprintRevision, blueprintId, requiresApproval) {
     await this.waitForEnvironment(environment.id);
 
-    const payload = {
+    const payload = removeEmptyValues({
       blueprintId,
       blueprintRevision,
-      userRequiresApproval: requiresApproval
-    };
+      userRequiresApproval: eval(requiresApproval)
+    });
 
     return await apiClient.callApi('post', `environments/${environment.id}/deployments`, {
-      data: removeEmptyValues(payload)
+      data: payload
     });
   }
 

--- a/node/src/lib/deploy-utils.js
+++ b/node/src/lib/deploy-utils.js
@@ -86,7 +86,7 @@ class DeployUtils {
     const payload = removeEmptyValues({
       blueprintId,
       blueprintRevision,
-      userRequiresApproval: eval(requiresApproval)
+      userRequiresApproval: requiresApproval
     });
 
     return await apiClient.callApi('post', `environments/${environment.id}/deployments`, {

--- a/node/src/lib/deploy-utils.js
+++ b/node/src/lib/deploy-utils.js
@@ -69,7 +69,7 @@ class DeployUtils {
     });
   }
 
-  async deployEnvironment(environment, blueprintRevision, blueprintId, requiresApproval) {
+  async deployEnvironment(environment, blueprintRevision, blueprintId, requiresApproval = false) {
     await this.waitForEnvironment(environment.id);
 
     return await apiClient.callApi('post', `environments/${environment.id}/deployments`, {

--- a/node/src/lib/genetal-utils.js
+++ b/node/src/lib/genetal-utils.js
@@ -1,0 +1,8 @@
+const convertRequiresApprovalToBoolean = str => {
+  if (str === 'true') return true;
+  if (str === 'false') return false;
+};
+
+module.exports = {
+  convertRequiresApprovalToBoolean
+};

--- a/node/src/lib/set-deployment-approval-status.js
+++ b/node/src/lib/set-deployment-approval-status.js
@@ -1,4 +1,5 @@
 const DeployUtils = require('../lib/deploy-utils');
+const logger = require('../lib/logger');
 
 const setDeploymentApprovalStatus = (command, shouldProcessDeploymentSteps) => async options => {
   const deployUtils = new DeployUtils();
@@ -15,7 +16,7 @@ const setDeploymentApprovalStatus = (command, shouldProcessDeploymentSteps) => a
 
   const { latestDeploymentLog } = environment;
 
-  if (command === 'approve') console.log('Approving deployment. Waiting for it to resume...');
+  if (command === 'approve') logger.info('Approving deployment. Waiting for it to resume...');
 
   command === 'approve'
     ? await deployUtils.approveDeployment(latestDeploymentLog.id)

--- a/node/src/lib/set-deployment-approval-status.js
+++ b/node/src/lib/set-deployment-approval-status.js
@@ -1,6 +1,6 @@
 const DeployUtils = require('../lib/deploy-utils');
 
-const setDeploymentApprovalStatus = command => async options => {
+const setDeploymentApprovalStatus = (command, shouldProcessDeploymentSteps) => async options => {
   const deployUtils = new DeployUtils();
 
   const environment = await deployUtils.getEnvironment(options.environmentName, options.projectId);
@@ -15,11 +15,13 @@ const setDeploymentApprovalStatus = command => async options => {
 
   const { latestDeploymentLog } = environment;
 
+  if (command === 'approve') console.log('Approving deployment. Waiting for it to resume...');
+
   command === 'approve'
     ? await deployUtils.approveDeployment(latestDeploymentLog.id)
     : await deployUtils.cancelDeployment(latestDeploymentLog.id);
 
-  const status = await deployUtils.pollDeploymentStatus(latestDeploymentLog.id);
+  const status = await deployUtils.pollDeploymentStatus(latestDeploymentLog.id, shouldProcessDeploymentSteps);
   deployUtils.assertDeploymentStatus(status);
 };
 

--- a/node/src/main.js
+++ b/node/src/main.js
@@ -54,7 +54,7 @@ const run = async () => {
 
     await runCommand(command, commandOptions, environmentVariables);
   } catch (error) {
-    console.error(`Command ${command} has failed. Error:`);
+    command && console.error(`Command ${command} has failed. Error:`);
     let { message } = error;
     if (error.response && error.response.data && error.response.data.message) {
       message += `: ${error.response.data.message}`;

--- a/node/tests/commands/configure.spec.js
+++ b/node/tests/commands/configure.spec.js
@@ -1,0 +1,20 @@
+const configure = require('../../src/commands/configure');
+const configManager = require('../../src/lib/config-manager');
+const inquirer = require('inquirer');
+
+jest.mock('inquirer');
+jest.mock('../../src/lib/config-manager');
+
+describe('configure', () => {
+  beforeEach(() => {
+    jest
+      .spyOn(inquirer, 'prompt')
+      .mockResolvedValue({ first: 'first', second: 'second', empty1: '', empty2: null, empty3: undefined });
+  });
+
+  it('should remove empty answers', async () => {
+    await configure();
+
+    expect(configManager.write).toBeCalledWith({ first: 'first', second: 'second' });
+  });
+});

--- a/node/tests/commands/deploy.spec.js
+++ b/node/tests/commands/deploy.spec.js
@@ -1,0 +1,37 @@
+const deploy = require('../../src/commands/deploy');
+const DeployUtils = require('../../src/lib/deploy-utils');
+const { options } = require('../../src/config/constants');
+
+const { REQUIRES_APPROVAL } = options;
+
+const mockGetEnvironment = jest.fn();
+const mockCreateEnvironment = jest.fn();
+const mockDeployEnvironment = jest.fn();
+
+jest.mock('../../src/lib/deploy-utils');
+
+describe('deploy', () => {
+  beforeEach(() => {
+    DeployUtils.mockImplementation(() => ({
+      getEnvironment: mockGetEnvironment,
+      createEnvironment: mockCreateEnvironment,
+      deployEnvironment: mockDeployEnvironment,
+      pollDeploymentStatus: jest.fn(),
+      assertDeploymentStatus: jest.fn()
+    }));
+  });
+
+  describe('requires approval argument', () => {
+    it.each`
+      requiresApproval | expected
+      ${'true'}        | ${true}
+      ${'false'}       | ${false}
+      ${undefined}     | ${undefined}
+    `('should process requires approval argument properly', async ({ requiresApproval, expected }) => {
+      mockDeployEnvironment.mockResolvedValue({ id: 'deployment0' });
+      await deploy({ [REQUIRES_APPROVAL]: requiresApproval });
+
+      expect(mockDeployEnvironment).toBeCalledWith(undefined, undefined, undefined, expected);
+    });
+  });
+});

--- a/node/tests/commands/destroy.spec.js
+++ b/node/tests/commands/destroy.spec.js
@@ -1,0 +1,61 @@
+const DeployUtils = require('../../src/lib/deploy-utils');
+const destroy = require('../../src/commands/destroy');
+const { options } = require('../../src/config/constants');
+
+const mockGetEnvironment = jest.fn();
+const mockUpdateEnvironment = jest.fn();
+const mockDestroyEnvironment = jest.fn();
+
+jest.mock('../../src/lib/deploy-utils');
+
+const { ENVIRONMENT_NAME, REQUIRES_APPROVAL } = options;
+
+describe('destroy', () => {
+  beforeEach(() => {
+    DeployUtils.mockImplementation(() => {
+      return {
+        getEnvironment: mockGetEnvironment,
+        updateEnvironment: mockUpdateEnvironment,
+        destroyEnvironment: mockDestroyEnvironment,
+        pollDeploymentStatus: jest.fn(),
+        assertDeploymentStatus: jest.fn()
+      };
+    });
+  });
+
+  it('should fail when environment doesnt exist', async () => {
+    const options = { [ENVIRONMENT_NAME]: 'environment0' };
+    mockGetEnvironment.mockResolvedValue(undefined);
+
+    await expect(destroy(options)).rejects.toThrow(Error, `Could not find an environment with the name environment0`);
+  });
+
+  describe('requires approval argument', () => {
+    it.each`
+      option       | existing
+      ${'true'}    | ${true}
+      ${'false'}   | ${false}
+      ${undefined} | ${''}
+    `('should not call update environment', async ({ option, existing }) => {
+      mockGetEnvironment.mockResolvedValue({ requiresApproval: existing });
+      mockDestroyEnvironment.mockResolvedValue({ id: 'deployment0' });
+
+      await destroy({ [REQUIRES_APPROVAL]: option });
+
+      expect(mockUpdateEnvironment).not.toBeCalled();
+    });
+
+    it.each`
+      option     | existing | expected
+      ${'true'}  | ${false} | ${true}
+      ${'false'} | ${true}  | ${false}
+    `('should call update environment', async ({ option, existing, expected }) => {
+      mockGetEnvironment.mockResolvedValue({ requiresApproval: existing });
+      mockDestroyEnvironment.mockResolvedValue({ id: 'deployment0' });
+
+      await destroy({ [REQUIRES_APPROVAL]: option });
+
+      expect(mockUpdateEnvironment).toBeCalledWith(expect.anything(), { requiresApproval: expected });
+    });
+  });
+});

--- a/node/tests/lib/deploy-utils.spec.js
+++ b/node/tests/lib/deploy-utils.spec.js
@@ -249,17 +249,12 @@ describe('deploy utils', () => {
     });
 
     it.each`
-      userRequiresApproval | expectedPayload
-      ${false}             | ${{ userRequiresApproval: false }}
-      ${undefined}         | ${{}}
-      ${true}              | ${{ userRequiresApproval: true }}
-    `('should remove undefined values from request payload', async ({ userRequiresApproval, expectedPayload }) => {
-      await deployUtils.deployEnvironment(
-        mockEnvironment,
-        mockBlueprintRevision,
-        mockBlueprintId,
-        userRequiresApproval
-      );
+      requiresApproval | expectedPayload
+      ${false}         | ${{ userRequiresApproval: false }}
+      ${undefined}     | ${{}}
+      ${true}          | ${{ userRequiresApproval: true }}
+    `('should remove undefined values from request payload', async ({ requiresApproval, expectedPayload }) => {
+      await deployUtils.deployEnvironment(mockEnvironment, mockBlueprintRevision, mockBlueprintId, requiresApproval);
 
       expect(mockCallApi).toHaveBeenLastCalledWith('post', `environments/${mockEnvironment.id}/deployments`, {
         data: {

--- a/node/tests/lib/deploy-utils.spec.js
+++ b/node/tests/lib/deploy-utils.spec.js
@@ -12,7 +12,7 @@ jest.mock('../../src/lib/api-client', () =>
 const mockEnvironmentId = 'environment0';
 const mockDeploymentId = 'deployment0';
 
-describe('deploy lib', () => {
+describe('deploy utils', () => {
   const deployUtils = new DeployUtils();
 
   describe('set configuration', () => {
@@ -244,6 +244,18 @@ describe('deploy lib', () => {
           blueprintId: mockBlueprintId,
           blueprintRevision: mockBlueprintRevision,
           userRequiresApproval: mockRequiresApproval
+        }
+      });
+    });
+
+    it('should set a default requires approval to false', async () => {
+      await deployUtils.deployEnvironment(mockEnvironment, mockBlueprintRevision, mockBlueprintId);
+
+      expect(mockCallApi).toHaveBeenLastCalledWith('post', `environments/${mockEnvironment.id}/deployments`, {
+        data: {
+          blueprintId: mockBlueprintId,
+          blueprintRevision: mockBlueprintRevision,
+          userRequiresApproval: false
         }
       });
     });

--- a/node/tests/lib/deploy-utils.spec.js
+++ b/node/tests/lib/deploy-utils.spec.js
@@ -248,14 +248,24 @@ describe('deploy utils', () => {
       });
     });
 
-    it('should set a default requires approval to false', async () => {
-      await deployUtils.deployEnvironment(mockEnvironment, mockBlueprintRevision, mockBlueprintId);
+    it.each`
+      userRequiresApproval | expectedPayload
+      ${false}             | ${{ userRequiresApproval: false }}
+      ${undefined}         | ${{}}
+      ${true}              | ${{ userRequiresApproval: true }}
+    `('should remove undefined values from request payload', async ({ userRequiresApproval, expectedPayload }) => {
+      await deployUtils.deployEnvironment(
+        mockEnvironment,
+        mockBlueprintRevision,
+        mockBlueprintId,
+        userRequiresApproval
+      );
 
       expect(mockCallApi).toHaveBeenLastCalledWith('post', `environments/${mockEnvironment.id}/deployments`, {
         data: {
           blueprintId: mockBlueprintId,
           blueprintRevision: mockBlueprintRevision,
-          userRequiresApproval: false
+          ...expectedPayload
         }
       });
     });

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1322,7 +1322,7 @@ expand-brackets@^2.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-expect@^24.9.0:
+expect@^24.1.0, expect@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/expect/-/expect-24.9.0.tgz#b75165b4817074fa4a157794f46fe9f1ba15b6ca"
   integrity sha512-wvVAx8XIol3Z5m9zvZXiyZOQ+sRJqNTIm6sGjdWlaZIeupQGO3WbYI+15D/AmEwZywL6wtJkbAbJtzkOfBuR0Q==
@@ -2169,6 +2169,20 @@ jest-environment-node@^24.9.0:
     jest-mock "^24.9.0"
     jest-util "^24.9.0"
 
+jest-extended@^0.11.5:
+  version "0.11.5"
+  resolved "https://registry.yarnpkg.com/jest-extended/-/jest-extended-0.11.5.tgz#f063b3f1eaadad8d7c13a01f0dfe0f538d498ccf"
+  integrity sha512-3RsdFpLWKScpsLD6hJuyr/tV5iFOrw7v6YjA3tPdda9sJwoHwcMROws5gwiIZfcwhHlJRwFJB2OUvGmF3evV/Q==
+  dependencies:
+    expect "^24.1.0"
+    jest-get-type "^22.4.3"
+    jest-matcher-utils "^22.0.0"
+
+jest-get-type@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-22.4.3.tgz#e3a8504d8479342dd4420236b322869f18900ce4"
+  integrity sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==
+
 jest-get-type@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-24.9.0.tgz#1684a0c8a50f2e4901b6644ae861f579eed2ef0e"
@@ -2222,6 +2236,15 @@ jest-leak-detector@^24.9.0:
   dependencies:
     jest-get-type "^24.9.0"
     pretty-format "^24.9.0"
+
+jest-matcher-utils@^22.0.0:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz#4632fe428ebc73ebc194d3c7b65d37b161f710ff"
+  integrity sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==
+  dependencies:
+    chalk "^2.0.1"
+    jest-get-type "^22.4.3"
+    pretty-format "^22.4.3"
 
 jest-matcher-utils@^24.9.0:
   version "24.9.0"
@@ -3064,6 +3087,14 @@ prettier@^2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.5.tgz#d6d56282455243f2f92cc1716692c08aa31522d4"
   integrity sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==
+
+pretty-format@^22.4.3:
+  version "22.4.3"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-22.4.3.tgz#f873d780839a9c02e9664c8a082e9ee79eaac16f"
+  integrity sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==
+  dependencies:
+    ansi-regex "^3.0.0"
+    ansi-styles "^3.2.0"
 
 pretty-format@^24.9.0:
   version "24.9.0"


### PR DESCRIPTION
### Issue & Steps to Reproduce
1. On deploy - should not send an `undefined` requires approval value.
2. On destroy - updating requires approval before destroying was missing.
3. Revision overrides the environment's revisions due to its default value (master).
4. Requires approval argument was changed from `boolean` to `string` since not stating it should use previous value.
5. `env0 cancel` should not print logs.

### Solution
1. Remove empty values on deploy.
2. Add that flow (similar to UI)
3. Remove the default value of revision.
4. Changed argument type.
5. Added a `shouldProcessDeploymentLogs` flag to deployment polling.
6. Fixed/Changed some problematic prints.
