### PR TITLE
Feat: add partial apply support

### DIFF
--- a/node/src/commands/deploy.js
+++ b/node/src/commands/deploy.js
@@ -1,6 +1,5 @@
 const DeployUtils = require('../lib/deploy-utils');
 const logger = require('../lib/logger');
-const { convertRequiresApprovalToBoolean } = require('../lib/genetal-utils');
 
 const setConfigurationFromOptions = async (environmentVariables, environment, blueprintId) => {
   const deployUtils = new DeployUtils();
@@ -18,7 +17,7 @@ const setConfigurationFromOptions = async (environmentVariables, environment, bl
 const deploy = async (options, environmentVariables) => {
   const deployUtils = new DeployUtils();
 
-  const { environmentName, projectId, organizationId, blueprintId, revision, requiresApproval } = options;
+  const { environmentName, projectId, organizationId, blueprintId } = options;
 
   logger.info('Waiting for deployment to start...');
   let environment = await deployUtils.getEnvironment(environmentName, projectId);
@@ -29,12 +28,7 @@ const deploy = async (options, environmentVariables) => {
 
   await setConfigurationFromOptions(environmentVariables, environment, blueprintId);
 
-  const deployment = await deployUtils.deployEnvironment(
-    environment,
-    revision,
-    blueprintId,
-    convertRequiresApprovalToBoolean(requiresApproval)
-  );
+  const deployment = await deployUtils.deployEnvironment(environment, options);
   const status = await deployUtils.pollDeploymentStatus(deployment.id);
 
   deployUtils.assertDeploymentStatus(status);

--- a/node/src/commands/destroy.js
+++ b/node/src/commands/destroy.js
@@ -27,7 +27,7 @@ const destroy = async options => {
     await deployUtils.updateEnvironment(environment, { requiresApproval: requiresApproval });
   }
 
-  const deployment = await deployUtils.destroyEnvironment(environment);
+  const deployment = await deployUtils.destroyEnvironment(environment, options);
   status = await deployUtils.pollDeploymentStatus(deployment.id);
 
   deployUtils.assertDeploymentStatus(status);

--- a/node/src/commands/destroy.js
+++ b/node/src/commands/destroy.js
@@ -27,7 +27,7 @@ const destroy = async options => {
     await deployUtils.updateEnvironment(environment, { requiresApproval: requiresApproval });
   }
 
-  const deployment = await deployUtils.destroyEnvironment(environment, options);
+  const deployment = await deployUtils.destroyEnvironment(environment);
   status = await deployUtils.pollDeploymentStatus(deployment.id);
 
   deployUtils.assertDeploymentStatus(status);

--- a/node/src/config/arguments.js
+++ b/node/src/config/arguments.js
@@ -10,7 +10,8 @@ const {
   ENVIRONMENT_VARIABLES,
   SENSITIVE_ENVIRONMENT_VARIABLES,
   REVISION,
-  REQUIRES_APPROVAL
+  REQUIRES_APPROVAL,
+  TARGETS
 } = options;
 
 const argumentsMap = {
@@ -82,6 +83,13 @@ const argumentsMap = {
     alias: 'r',
     type: String,
     description: 'Your git revision, can be a branch tag or a commit hash. Default value "master" '
+  },
+  [TARGETS]: {
+    name: TARGETS,
+    alias: 't',
+    type: String,
+    description:
+      'A list of resources to explicitly include in the deployment, delimited by comma. Format is "resource1,resource2,resource3"'
   }
 };
 

--- a/node/src/config/commands.js
+++ b/node/src/config/commands.js
@@ -1,4 +1,7 @@
-const { allArguments, baseArguments } = require('./arguments');
+const { argumentsMap, allArguments, baseArguments } = require('./arguments');
+const { options } = require('./constants');
+
+const { REQUIRES_APPROVAL, REVISION, ENVIRONMENT_VARIABLES, SENSITIVE_ENVIRONMENT_VARIABLES } = options;
 
 const commands = {
   deploy: {
@@ -6,7 +9,13 @@ const commands = {
     description: 'Deploys an environment'
   },
   destroy: {
-    options: allArguments,
+    options: [
+      ...baseArguments,
+      argumentsMap[REQUIRES_APPROVAL],
+      argumentsMap[REVISION],
+      argumentsMap[ENVIRONMENT_VARIABLES],
+      argumentsMap[SENSITIVE_ENVIRONMENT_VARIABLES]
+    ],
     description: 'Destroys an environment'
   },
   approve: {

--- a/node/src/config/constants.js
+++ b/node/src/config/constants.js
@@ -8,7 +8,8 @@ const options = {
   ENVIRONMENT_VARIABLES: 'environmentVariables',
   SENSITIVE_ENVIRONMENT_VARIABLES: 'sensitiveEnvironmentVariables',
   REVISION: 'revision',
-  REQUIRES_APPROVAL: 'requiresApproval'
+  REQUIRES_APPROVAL: 'requiresApproval',
+  TARGETS: 'targets'
 };
 
 module.exports = {

--- a/node/src/lib/deploy-utils.js
+++ b/node/src/lib/deploy-utils.js
@@ -96,14 +96,10 @@ class DeployUtils {
     });
   }
 
-  async destroyEnvironment(environment, options) {
+  async destroyEnvironment(environment) {
     await this.waitForEnvironment(environment.id);
 
-    const payload = removeEmptyValues({
-      targets: options[TARGETS]
-    });
-
-    return await apiClient.callApi('post', `environments/${environment.id}/destroy`, { data: payload });
+    return await apiClient.callApi('post', `environments/${environment.id}/destroy`);
   }
 
   async writeDeploymentStepLog(deploymentLogId, stepName) {

--- a/node/src/lib/deploy-utils.js
+++ b/node/src/lib/deploy-utils.js
@@ -2,8 +2,9 @@ const Env0ApiClient = require('./api-client');
 const logger = require('./logger');
 const _ = require('lodash');
 const { options } = require('../config/constants');
+const { convertRequiresApprovalToBoolean } = require('../lib/genetal-utils');
 
-const { API_KEY, API_SECRET } = options;
+const { API_KEY, API_SECRET, REQUIRES_APPROVAL, BLUEPRINT_ID, REVISION, TARGETS } = options;
 
 const apiClient = new Env0ApiClient();
 
@@ -80,13 +81,14 @@ class DeployUtils {
     });
   }
 
-  async deployEnvironment(environment, blueprintRevision, blueprintId, requiresApproval) {
+  async deployEnvironment(environment, options) {
     await this.waitForEnvironment(environment.id);
 
     const payload = removeEmptyValues({
-      blueprintId,
-      blueprintRevision,
-      userRequiresApproval: requiresApproval
+      blueprintId: options[BLUEPRINT_ID],
+      blueprintRevision: options[REVISION],
+      userRequiresApproval: convertRequiresApprovalToBoolean(options[REQUIRES_APPROVAL]),
+      targets: options[TARGETS]
     });
 
     return await apiClient.callApi('post', `environments/${environment.id}/deployments`, {
@@ -94,10 +96,14 @@ class DeployUtils {
     });
   }
 
-  async destroyEnvironment(environment) {
+  async destroyEnvironment(environment, options) {
     await this.waitForEnvironment(environment.id);
 
-    return await apiClient.callApi('post', `environments/${environment.id}/destroy`);
+    const payload = removeEmptyValues({
+      targets: options[TARGETS]
+    });
+
+    return await apiClient.callApi('post', `environments/${environment.id}/destroy`, { data: payload });
   }
 
   async writeDeploymentStepLog(deploymentLogId, stepName) {

--- a/node/tests/commands/destroy.spec.js
+++ b/node/tests/commands/destroy.spec.js
@@ -9,7 +9,7 @@ const mockDestroyEnvironment = jest.fn();
 jest.mock('../../src/lib/logger');
 jest.mock('../../src/lib/deploy-utils');
 
-const { ENVIRONMENT_NAME, REQUIRES_APPROVAL, TARGETS } = options;
+const { ENVIRONMENT_NAME, REQUIRES_APPROVAL } = options;
 
 describe('destroy', () => {
   beforeEach(() => {

--- a/node/tests/commands/destroy.spec.js
+++ b/node/tests/commands/destroy.spec.js
@@ -26,14 +26,13 @@ describe('destroy', () => {
 
   it('should call api with proper data', async () => {
     const mockEnvironment = { id: 'something', name: 'someone' };
-    const mockOptions = { [TARGETS]: 'target1,target2' };
 
     mockGetEnvironment.mockResolvedValue(mockEnvironment);
     mockDestroyEnvironment.mockResolvedValue({ id: 'id0' });
 
-    await destroy(mockOptions);
+    await destroy({});
 
-    expect(mockDestroyEnvironment).toBeCalledWith(mockEnvironment, mockOptions);
+    expect(mockDestroyEnvironment).toBeCalledWith(mockEnvironment);
   });
 
   it('should fail when environment doesnt exist', async () => {

--- a/node/tests/commands/destroy.spec.js
+++ b/node/tests/commands/destroy.spec.js
@@ -6,9 +6,10 @@ const mockGetEnvironment = jest.fn();
 const mockUpdateEnvironment = jest.fn();
 const mockDestroyEnvironment = jest.fn();
 
+jest.mock('../../src/lib/logger');
 jest.mock('../../src/lib/deploy-utils');
 
-const { ENVIRONMENT_NAME, REQUIRES_APPROVAL } = options;
+const { ENVIRONMENT_NAME, REQUIRES_APPROVAL, TARGETS } = options;
 
 describe('destroy', () => {
   beforeEach(() => {
@@ -23,11 +24,26 @@ describe('destroy', () => {
     });
   });
 
+  it('should call api with proper data', async () => {
+    const mockEnvironment = { id: 'something', name: 'someone' };
+    const mockOptions = { [TARGETS]: 'target1,target2' };
+
+    mockGetEnvironment.mockResolvedValue(mockEnvironment);
+    mockDestroyEnvironment.mockResolvedValue({ id: 'id0' });
+
+    await destroy(mockOptions);
+
+    expect(mockDestroyEnvironment).toBeCalledWith(mockEnvironment, mockOptions);
+  });
+
   it('should fail when environment doesnt exist', async () => {
-    const options = { [ENVIRONMENT_NAME]: 'environment0' };
+    const mockEnvironmentName = 'environment0';
     mockGetEnvironment.mockResolvedValue(undefined);
 
-    await expect(destroy(options)).rejects.toThrow(Error, `Could not find an environment with the name environment0`);
+    await expect(destroy({ [ENVIRONMENT_NAME]: mockEnvironmentName })).rejects.toThrow(
+      Error,
+      `Could not find an environment with the name ${mockEnvironmentName}`
+    );
   });
 
   describe('requires approval argument', () => {

--- a/node/tests/lib/deploy-utils.spec.js
+++ b/node/tests/lib/deploy-utils.spec.js
@@ -284,4 +284,22 @@ describe('deploy utils', () => {
       expect(mockCallApi).toBeCalledWith('put', `environments/deployments/${mockDeploymentId}/cancel`);
     });
   });
+
+  describe('destroy environment', () => {
+    const mockOptions = {
+      [TARGETS]: 'target1, target2'
+    };
+
+    it('should call api with proper data', async () => {
+      mockCallApi.mockResolvedValueOnce({ status: 'ACTIVE' });
+
+      await deployUtils.destroyEnvironment({ id: mockEnvironmentId }, mockOptions);
+
+      expect(mockCallApi).toBeCalledWith('post', `environments/${mockEnvironmentId}/destroy`, {
+        data: {
+          targets: mockOptions[TARGETS]
+        }
+      });
+    });
+  });
 });

--- a/node/tests/lib/deploy-utils.spec.js
+++ b/node/tests/lib/deploy-utils.spec.js
@@ -284,22 +284,4 @@ describe('deploy utils', () => {
       expect(mockCallApi).toBeCalledWith('put', `environments/deployments/${mockDeploymentId}/cancel`);
     });
   });
-
-  describe('destroy environment', () => {
-    const mockOptions = {
-      [TARGETS]: 'target1, target2'
-    };
-
-    it('should call api with proper data', async () => {
-      mockCallApi.mockResolvedValueOnce({ status: 'ACTIVE' });
-
-      await deployUtils.destroyEnvironment({ id: mockEnvironmentId }, mockOptions);
-
-      expect(mockCallApi).toBeCalledWith('post', `environments/${mockEnvironmentId}/destroy`, {
-        data: {
-          targets: mockOptions[TARGETS]
-        }
-      });
-    });
-  });
 });


### PR DESCRIPTION
### Feature Request
A user should be able to use `terraform`'s `-target` parameter for applying his deployment on a partial set of the resources he had previously deployed (aka partial apply).

### Solution
BE already supports the `targets` parameter for deploy and destroy APIs. Just passing it along 😺 

