### PR TITLE
chore: upgraded the help

### DIFF
--- a/node/src/commands/help.js
+++ b/node/src/commands/help.js
@@ -2,9 +2,7 @@ const commandLineUsage = require('command-line-usage');
 const boxen = require('boxen');
 const { allArguments } = require('../config/arguments');
 const { commands } = require('../config/commands');
-const { options } = require('../config/constants');
-
-const { API_KEY, API_SECRET, ORGANIZATION_ID, PROJECT_ID, ENVIRONMENT_NAME, BLUEPRINT_ID } = options;
+const { repository } = require('../../package.json');
 
 const header = `
                                   .oooo.   
@@ -16,19 +14,23 @@ d88' \`88b \`888P"Y88b \`88.  .8'  888    888
 \`Y8bod8P' o888o o888o   \`8'      \`Y8bd8P'  
 
 Self-Service Cloud Environments
+https://www.env0.com
 `;
+
+const options = Object.keys(commands)
+  .filter(command => commands[command].options)
+  .map(command => ({
+    header: `${command} options`,
+    optionList: allArguments.map(option => ({
+      ...option
+    })),
+    group: [ command ]
+  }));
 
 const sections = [
   {
     content: boxen(header, { padding: 1, margin: 1, borderStyle: 'bold', align: 'center' }),
     raw: true
-  },
-  {
-    header: 'Usage',
-    content: [
-      `$ env0 deploy -k <${API_KEY}> -s <${API_SECRET}> -o <${ORGANIZATION_ID}> -p <${PROJECT_ID}> -b <${BLUEPRINT_ID}> -e <${ENVIRONMENT_NAME}> -r [revision] -v [stage=dev]`,
-      '$ env0 --help'
-    ]
   },
   {
     header: 'Available Commands',
@@ -37,11 +39,16 @@ const sections = [
       summary: commands[command].description
     }))
   },
+  ...options,
   {
-    header: 'Options',
-    optionList: allArguments.map(option => ({
-      ...option
+    header: 'Examples',
+    content: Object.keys(commands).map(command => ({
+      desc: commands[command].description,
+      example: commands[command].example,
     }))
+  },
+  {
+    content: `Project home: {underline ${repository.url}}`
   }
 ];
 

--- a/node/src/config/arguments.js
+++ b/node/src/config/arguments.js
@@ -21,7 +21,8 @@ const argumentsMap = {
     type: String,
     description: 'env0 API Key',
     prompt: 'env0 API Key',
-    secret: true
+    secret: true,
+    group: ['deploy', 'destroy', 'approve', 'cancel']
   },
   [API_SECRET]: {
     name: API_SECRET,
@@ -29,36 +30,41 @@ const argumentsMap = {
     type: String,
     description: 'env0 API Secret',
     prompt: 'env0 API Secret',
-    secret: true
+    secret: true,
+    group: ['deploy', 'destroy', 'approve', 'cancel']
   },
   [ORGANIZATION_ID]: {
     name: ORGANIZATION_ID,
     alias: 'o',
     type: String,
     description: 'env0 Organization ID',
-    prompt: 'Organization ID'
+    prompt: 'Organization ID',
+    group: ['deploy', 'destroy', 'approve', 'cancel']
   },
   [PROJECT_ID]: { name: PROJECT_ID, alias: 'p', type: String, description: 'env0 Project ID', prompt: 'Project ID' },
   [ENVIRONMENT_NAME]: {
     name: ENVIRONMENT_NAME,
     alias: 'e',
     type: String,
-    description: 'The environment name you would like to create, if it exists it will deploy to that environment',
-    prompt: 'Environment Name'
+    description: 'The environment name you want to perform the action on',
+    prompt: 'Environment Name',
+    group: ['deploy', 'destroy', 'approve', 'cancel']
   },
   [BLUEPRINT_ID]: {
     name: BLUEPRINT_ID,
     alias: 'b',
     type: String,
     description: 'The Blueprint id you would like to deploy',
-    prompt: 'Blueprint ID'
+    prompt: 'Blueprint ID',
+    group: ['deploy']
   },
   [REQUIRES_APPROVAL]: {
     name: REQUIRES_APPROVAL,
     alias: 'a',
     type: String,
+    group: ['deploy', 'destroy'],
     description:
-      'Whether deployment should wait for approval on plan stage before deploying your environment. Can be either "true" or "false"'
+      'Whether deploy/destroy should wait for approval on plan stage before deploy/destroy your environment. Can be either "true" or "false"'
   },
   [ENVIRONMENT_VARIABLES]: {
     name: ENVIRONMENT_VARIABLES,
@@ -66,6 +72,7 @@ const argumentsMap = {
     type: String,
     multiple: true,
     defaultValue: [],
+    group: ['deploy'],
     description:
       'The environment variables to set on the deployed environment - works only on deploy and can be multiple, the format is "environmentVariableName1=value"'
   },
@@ -75,6 +82,7 @@ const argumentsMap = {
     type: String,
     multiple: true,
     defaultValue: [],
+    group: ['deploy'],
     description:
       'The sensitive environment variables to set on the deployed environment - works only on deploy and can be multiple, the format is "environmentVariableName1=value"'
   },
@@ -82,12 +90,14 @@ const argumentsMap = {
     name: REVISION,
     alias: 'r',
     type: String,
+    group: ['deploy'],
     description: 'Your git revision, can be a branch tag or a commit hash. Default value "master" '
   },
   [TARGETS]: {
     name: TARGETS,
     alias: 't',
     type: String,
+    group: ['deploy'],
     description:
       'A list of resources to explicitly include in the deployment, delimited by comma. Format is "resource1,resource2,resource3"'
   }

--- a/node/src/config/commands.js
+++ b/node/src/config/commands.js
@@ -1,39 +1,43 @@
 const { argumentsMap, allArguments, baseArguments } = require('./arguments');
 const { options } = require('./constants');
 
-const { REQUIRES_APPROVAL, REVISION, ENVIRONMENT_VARIABLES, SENSITIVE_ENVIRONMENT_VARIABLES } = options;
+const { API_KEY, API_SECRET, ORGANIZATION_ID, PROJECT_ID, ENVIRONMENT_NAME, BLUEPRINT_ID, REQUIRES_APPROVAL } = options;
 
 const commands = {
   deploy: {
     options: allArguments,
-    description: 'Deploys an environment'
+    description: 'Deploys an environment',
+    example: `$ env0 deploy -k <${API_KEY}> -s <${API_SECRET}> -o <${ORGANIZATION_ID}> -p <${PROJECT_ID}> -b <${BLUEPRINT_ID}> -e <${ENVIRONMENT_NAME}> -r [revision] -v [stage=dev]`
   },
   destroy: {
     options: [
       ...baseArguments,
-      argumentsMap[REQUIRES_APPROVAL],
-      argumentsMap[REVISION],
-      argumentsMap[ENVIRONMENT_VARIABLES],
-      argumentsMap[SENSITIVE_ENVIRONMENT_VARIABLES]
+      argumentsMap[REQUIRES_APPROVAL]
     ],
-    description: 'Destroys an environment'
+    description: 'Destroys an environment',
+    example: `$ env0 destroy -k <${API_KEY}> -s <${API_SECRET}> -o <${ORGANIZATION_ID}> -p <${PROJECT_ID}> -e <${ENVIRONMENT_NAME}>\n`
   },
   approve: {
     options: baseArguments,
-    description: 'Accepts a deployment that is pending approval'
+    description: 'Accepts a deployment that is pending approval',
+    example: `$ env0 approve -k <${API_KEY}> -s <${API_SECRET}> -o <${ORGANIZATION_ID}> -p <${PROJECT_ID}> -e <${ENVIRONMENT_NAME}>\n`
   },
   cancel: {
     options: baseArguments,
-    description: 'Cancels an deployment that is pending approval'
+    description: 'Cancels a deployment that is pending approval',
+    example: `$ env0 cancel -k <${API_KEY}> -s <${API_SECRET}> -o <${ORGANIZATION_ID}> -p <${PROJECT_ID}> -e <${ENVIRONMENT_NAME}>\n`
   },
   configure: {
-    description: 'Configures env0 CLI options'
+    description: 'Configures env0 CLI options',
+    example: `$ env0 configure`,
   },
   version: {
-    description: 'Shows the CLI version'
+    description: 'Shows the CLI version',
+    example: `$ env0 version`
   },
   help: {
-    description: 'Shows this help message'
+    description: 'Shows this help message',
+    example: `$ env0 help`
   }
 };
 


### PR DESCRIPTION
### Feature Request
We wanted to have a better `env0 help` command
### Solution
1. Added a link to the github repo.
2. Added link to env0 in the Banner.
3. Changed the option list to be per command.
4. Added examples to each command.

![image](https://user-images.githubusercontent.com/46656490/89729551-7ccfa800-da3f-11ea-8f12-4478f0641d82.png)
![image](https://user-images.githubusercontent.com/46656490/89729553-83f6b600-da3f-11ea-9767-f476360aae10.png)

fixes https://github.com/env0/env0-client-integrations/issues/43