### PR TITLE
Fix: passing command options

### DIFF
--- a/node/src/config/arguments.js
+++ b/node/src/config/arguments.js
@@ -41,7 +41,14 @@ const argumentsMap = {
     prompt: 'Organization ID',
     group: ['deploy', 'destroy', 'approve', 'cancel']
   },
-  [PROJECT_ID]: { name: PROJECT_ID, alias: 'p', type: String, description: 'env0 Project ID', prompt: 'Project ID' },
+  [PROJECT_ID]: {
+    name: PROJECT_ID,
+    alias: 'p',
+    type: String,
+    description: 'env0 Project ID',
+    prompt: 'Project ID',
+    group: ['deploy', 'destroy', 'approve', 'cancel']
+  },
   [ENVIRONMENT_NAME]: {
     name: ENVIRONMENT_NAME,
     alias: 'e',

--- a/node/src/main.js
+++ b/node/src/main.js
@@ -53,14 +53,16 @@ const run = async () => {
     assertCommandExists(command);
 
     const commandDefinitions = commands[command].options;
-    const commandOptions = commandLineArgs(commandDefinitions, { argv });
+    const commandsOptions = commandLineArgs(commandDefinitions, { argv });
+
+    const currentCommandOptions = commandsOptions[command];
 
     const environmentVariables = getEnvironmentVariablesOptions(
-      commandOptions[ENVIRONMENT_VARIABLES],
-      commandOptions[SENSITIVE_ENVIRONMENT_VARIABLES]
+      currentCommandOptions[ENVIRONMENT_VARIABLES],
+      currentCommandOptions[SENSITIVE_ENVIRONMENT_VARIABLES]
     );
 
-    await runCommand(command, commandOptions, environmentVariables);
+    await runCommand(command, currentCommandOptions, environmentVariables);
   } catch (error) {
     commands[command] && logger.error(`Command ${command} has failed. Error:`);
     let { message } = error;

--- a/node/tests/main.spec.js
+++ b/node/tests/main.spec.js
@@ -12,14 +12,16 @@ jest.mock('../src/commands/help');
 jest.mock('../src/commands/configure');
 jest.mock('command-line-args');
 
-const mockOptions = {
-  help: false,
-  blue: 'pill',
-  red: 'pill',
-  environmentVariables: ['key1=value1', 'key2=value2'],
-  sensitiveEnvironmentVariables: ['sensitiveKey1=sensitiveValue1', 'sensitiveKey2=sensitiveValue2'],
+const getMockOptions = command => ({
+  [command]: {
+    help: false,
+    blue: 'pill',
+    red: 'pill',
+    environmentVariables: ['key1=value1', 'key2=value2'],
+    sensitiveEnvironmentVariables: ['sensitiveKey1=sensitiveValue1', 'sensitiveKey2=sensitiveValue2']
+  },
   _unknown: ['test']
-};
+});
 
 const mockOptionsAndRun = async ({ command, rawArgs, args }) => {
   commandLineArgs.mockReturnValueOnce({ command, _unknown: rawArgs });
@@ -103,10 +105,12 @@ describe('main', () => {
 
     describe('environment variables parsing', () => {
       describe.each`
-        command      | args
-        ${'deploy'}  | ${mockOptions}
-        ${'destroy'} | ${mockOptions}
-      `('on $command', ({ command, args }) => {
+        command
+        ${'deploy'}
+        ${'destroy'}
+      `('on $command', ({ command }) => {
+        const args = getMockOptions(command);
+
         beforeEach(async () => {
           await mockOptionsAndRun({ command, args });
         });
@@ -119,7 +123,7 @@ describe('main', () => {
         ];
 
         it('should run deployment with proper params', () => {
-          expect(runCommand).toBeCalledWith(command, expect.objectContaining(args), expectedEnvVars);
+          expect(runCommand).toBeCalledWith(command, expect.objectContaining(args[command]), expectedEnvVars);
         });
       });
     });


### PR DESCRIPTION
### Issue & Steps to Reproduce
After #43 was merged, there are now `groups` of options per command, so we now need to extract the relevant arguments object of the command from the general arguments object that contains the groups.

### Solution
As described.

