### PR TITLE
Fix: assert blueprint id for initial deployment

### DIFF
--- a/node/src/commands/deploy.js
+++ b/node/src/commands/deploy.js
@@ -1,5 +1,8 @@
 const DeployUtils = require('../lib/deploy-utils');
 const logger = require('../lib/logger');
+const { options } = require('../config/constants');
+
+const { BLUEPRINT_ID } = options;
 
 const setConfigurationFromOptions = async (environmentVariables, environment, blueprintId) => {
   const deployUtils = new DeployUtils();
@@ -14,6 +17,10 @@ const setConfigurationFromOptions = async (environmentVariables, environment, bl
   }
 };
 
+const assertBlueprintExistsOnInitialDeployment = options => {
+  if (!options[BLUEPRINT_ID]) throw new Error('Missing blueprint ID on initial deployment');
+};
+
 const deploy = async (options, environmentVariables) => {
   const deployUtils = new DeployUtils();
 
@@ -23,6 +30,7 @@ const deploy = async (options, environmentVariables) => {
   let environment = await deployUtils.getEnvironment(environmentName, projectId);
 
   if (!environment) {
+    assertBlueprintExistsOnInitialDeployment(options);
     environment = await deployUtils.createEnvironment(environmentName, organizationId, projectId);
   }
 

--- a/node/tests/commands/deploy.spec.js
+++ b/node/tests/commands/deploy.spec.js
@@ -7,7 +7,11 @@ const { ENVIRONMENT_NAME, PROJECT_ID, ORGANIZATION_ID, BLUEPRINT_ID } = options;
 const mockOptions = {
   [PROJECT_ID]: 'project0',
   [ENVIRONMENT_NAME]: 'environment0',
-  [ORGANIZATION_ID]: 'organization0',
+  [ORGANIZATION_ID]: 'organization0'
+};
+
+const mockOptionsWithBlueprintId = {
+  ...mockOptions,
   [BLUEPRINT_ID]: 'blueprint0'
 };
 
@@ -34,7 +38,7 @@ describe('deploy', () => {
   });
 
   it('should get environment', async () => {
-    await deploy(mockOptions);
+    await deploy(mockOptionsWithBlueprintId);
 
     expect(mockGetEnvironment).toBeCalledWith(mockOptions[ENVIRONMENT_NAME], mockOptions[PROJECT_ID]);
   });
@@ -42,11 +46,19 @@ describe('deploy', () => {
   it("should create environment when it doesn't exist", async () => {
     mockGetEnvironment.mockResolvedValue(undefined);
 
-    await deploy(mockOptions);
+    await deploy(mockOptionsWithBlueprintId);
     expect(mockCreateEnvironment).toBeCalledWith(
       mockOptions[ENVIRONMENT_NAME],
       mockOptions[ORGANIZATION_ID],
       mockOptions[PROJECT_ID]
+    );
+  });
+
+  it('should fail when blueprint is missing on initial deployment', async () => {
+    mockGetEnvironment.mockResolvedValue(undefined);
+
+    await expect(deploy(mockOptions)).rejects.toThrow(
+      expect.objectContaining({ message: 'Missing blueprint ID on initial deployment' })
     );
   });
 });


### PR DESCRIPTION
### Issue & Steps to Reproduce
We call `create environment` first (which doesn't assert blueprint ID) and then after that we call `deploy environment` (which asserts blueprint ID on initial deployment). This leads to a scenario that when a user forgets to include blueprint ID argument then environment is created but never deployed.

P.S - Our CLI flow works a little different than UI (we use `create environment` and only after that we `set configuration` + `deploy environment`). We should instead do `create environment` using `deployRequest` and `configurationChanges` in request body, but that's reserved for a different [task](https://github.com/env0/env0-client-integrations/issues/49).

### Solution
In this PR I've introduced an assertion that takes place when environment doesn't exist (AKA initial deployment) and verifies that blueprint ID argument exists.

