### PR TITLE
Feat: queued deployments

### DIFF
--- a/node/src/commands/deploy.js
+++ b/node/src/commands/deploy.js
@@ -9,7 +9,8 @@ const assertBlueprintExistsOnInitialDeployment = options => {
 };
 
 const assertNoWorkspaceNameChanges = options => {
-  if (options[WORKSPACE_NAME]) throw new Error('You may only set Terraform Workspace on the first deployment of an environment');
+  if (options[WORKSPACE_NAME])
+    throw new Error('You may only set Terraform Workspace on the first deployment of an environment');
 };
 
 const getConfigurationChanges = environmentVariables =>
@@ -22,27 +23,23 @@ const getConfigurationChanges = environmentVariables =>
 
 const deploy = async (options, environmentVariables) => {
   const deployUtils = new DeployUtils();
-
-  logger.info('Waiting for deployment to start...');
-
   const configurationChanges = getConfigurationChanges(environmentVariables);
 
-  let deploymentLogId;
+  let deployment;
   let environment = await deployUtils.getEnvironment(options[ENVIRONMENT_NAME], options[PROJECT_ID]);
 
   if (!environment) {
-    logger.info('Initial deployment detected');
+    logger.info('Initial deployment detected!');
     assertBlueprintExistsOnInitialDeployment(options);
 
     environment = await deployUtils.createAndDeployEnvironment(options, configurationChanges);
-    deploymentLogId = environment.latestDeploymentLogId;
+    deployment = environment.latestDeploymentLog;
   } else {
     assertNoWorkspaceNameChanges(options);
-    const deployment = await deployUtils.deployEnvironment(environment, options, configurationChanges);
-    deploymentLogId = deployment.id;
+    deployment = await deployUtils.deployEnvironment(environment, options, configurationChanges);
   }
 
-  const status = await deployUtils.pollDeploymentStatus(deploymentLogId);
+  const status = await deployUtils.pollDeploymentStatus(deployment);
 
   deployUtils.assertDeploymentStatus(status);
 };

--- a/node/src/commands/destroy.js
+++ b/node/src/commands/destroy.js
@@ -1,7 +1,6 @@
 const DeployUtils = require('../lib/deploy-utils');
 const { options } = require('../config/constants');
 const _ = require('lodash');
-const logger = require('../lib/logger');
 const { convertStringToBoolean } = require('../lib/general-utils');
 
 const { PROJECT_ID, ENVIRONMENT_NAME, REQUIRES_APPROVAL } = options;
@@ -15,7 +14,6 @@ const assertEnvironmentExists = environment => {
 const destroy = async options => {
   const deployUtils = new DeployUtils();
 
-  logger.info('Waiting for deployment to start...');
   const environment = await deployUtils.getEnvironment(options[ENVIRONMENT_NAME], options[PROJECT_ID]);
   let status;
 
@@ -28,7 +26,8 @@ const destroy = async options => {
   }
 
   const deployment = await deployUtils.destroyEnvironment(environment);
-  status = await deployUtils.pollDeploymentStatus(deployment.id);
+
+  status = await deployUtils.pollDeploymentStatus(deployment);
 
   deployUtils.assertDeploymentStatus(status);
 };

--- a/node/src/lib/deploy-utils.js
+++ b/node/src/lib/deploy-utils.js
@@ -145,7 +145,7 @@ class DeployUtils {
 
       status === 'QUEUED' && logger.info('Waiting for deployment to start....');
 
-      if (status !== 'QUEUED' && previousStatus === 'QUEUED') {
+      if (status === 'IN_PROGRESS' && previousStatus === 'QUEUED') {
         logger.info(`Deployment reached its turn! ${type === 'deploy' ? 'Deploying' : 'Destroying'} environment...`);
       }
 

--- a/node/src/lib/deploy-utils.js
+++ b/node/src/lib/deploy-utils.js
@@ -143,7 +143,7 @@ class DeployUtils {
     while (true) {
       const { type, status } = await this.getDeployment(deployment.id);
 
-      status === 'QUEUED' && logger.info('Waiting for deployment to start....');
+      if (status === 'QUEUED') logger.info('Queued deployment is still waiting for earlier deployments to finish...');
 
       if (status === 'IN_PROGRESS' && previousStatus === 'QUEUED') {
         logger.info(`Deployment reached its turn! ${type === 'deploy' ? 'Deploying' : 'Destroying'} environment...`);

--- a/node/src/lib/deploy-utils.js
+++ b/node/src/lib/deploy-utils.js
@@ -132,7 +132,6 @@ class DeployUtils {
     const start = Date.now();
     const stepsAlreadyLogged = [];
     let previousStatus;
-    let shouldStartProcessingDeploymentLogs;
 
     const pollableStatuses = ['IN_PROGRESS'];
     if (deployment.status === 'QUEUED') {
@@ -143,7 +142,6 @@ class DeployUtils {
 
     while (true) {
       const { type, status } = await this.getDeployment(deployment.id);
-      shouldStartProcessingDeploymentLogs = status !== 'QUEUED';
 
       status === 'QUEUED' && logger.info('Waiting for deployment to start....');
 
@@ -151,7 +149,7 @@ class DeployUtils {
         logger.info(`Deployment reached its turn! ${type === 'deploy' ? 'Deploying' : 'Destroying'} environment...`);
       }
 
-      if (shouldStartProcessingDeploymentLogs && shouldProcessDeploymentSteps) {
+      if (shouldProcessDeploymentSteps) {
         stepsAlreadyLogged.push(...(await this.processDeploymentSteps(deployment.id, stepsAlreadyLogged)));
       }
 

--- a/node/src/lib/set-deployment-approval-status.js
+++ b/node/src/lib/set-deployment-approval-status.js
@@ -22,7 +22,7 @@ const setDeploymentApprovalStatus = (command, shouldProcessDeploymentSteps) => a
     ? await deployUtils.approveDeployment(latestDeploymentLog.id)
     : await deployUtils.cancelDeployment(latestDeploymentLog.id);
 
-  const status = await deployUtils.pollDeploymentStatus(latestDeploymentLog.id, shouldProcessDeploymentSteps);
+  const status = await deployUtils.pollDeploymentStatus(latestDeploymentLog, shouldProcessDeploymentSteps);
   deployUtils.assertDeploymentStatus(status);
 };
 

--- a/node/tests/commands/destroy.spec.js
+++ b/node/tests/commands/destroy.spec.js
@@ -5,9 +5,12 @@ const { options } = require('../../src/config/constants');
 const mockGetEnvironment = jest.fn();
 const mockUpdateEnvironment = jest.fn();
 const mockDestroyEnvironment = jest.fn();
+const mockPollDeploymentStatus = jest.fn();
 
 jest.mock('../../src/lib/logger');
 jest.mock('../../src/lib/deploy-utils');
+
+const mockDeployment = { id: 'id0' };
 
 const { ENVIRONMENT_NAME, REQUIRES_APPROVAL } = options;
 
@@ -18,7 +21,7 @@ describe('destroy', () => {
         getEnvironment: mockGetEnvironment,
         updateEnvironment: mockUpdateEnvironment,
         destroyEnvironment: mockDestroyEnvironment,
-        pollDeploymentStatus: jest.fn(),
+        pollDeploymentStatus: mockPollDeploymentStatus,
         assertDeploymentStatus: jest.fn()
       };
     });
@@ -28,11 +31,12 @@ describe('destroy', () => {
     const mockEnvironment = { id: 'something', name: 'someone' };
 
     mockGetEnvironment.mockResolvedValue(mockEnvironment);
-    mockDestroyEnvironment.mockResolvedValue({ id: 'id0' });
+    mockDestroyEnvironment.mockResolvedValue(mockDeployment);
 
     await destroy({});
 
     expect(mockDestroyEnvironment).toBeCalledWith(mockEnvironment);
+    expect(mockPollDeploymentStatus).toBeCalledWith(mockDeployment);
   });
 
   it('should fail when environment doesnt exist', async () => {


### PR DESCRIPTION
### Feature Request
Support queued deployments.

### Solution
1. Deploy/Destroy should not wait for environment status any longer.
2. Poll deployment should support `QUEUED` status by waiting for it to finish and printing proper logs.

