### PR TITLE
Fix: add missing scope in configuration changes

### DIFF
--- a/node/src/commands/deploy.js
+++ b/node/src/commands/deploy.js
@@ -15,6 +15,7 @@ const assertNoWorkspaceNameChanges = options => {
 
 const getConfigurationChanges = environmentVariables =>
   (environmentVariables || []).map(variable => ({
+    scope: 'DEPLOYMENT',
     isSensitive: variable.sensitive,
     name: variable.name,
     value: variable.value,

--- a/node/tests/commands/deploy.spec.js
+++ b/node/tests/commands/deploy.spec.js
@@ -72,6 +72,7 @@ describe('deploy', () => {
     ];
 
     const expectedConfigurationChanges = environmentVariables.map(variable => ({
+      scope: 'DEPLOYMENT',
       name: variable.name,
       value: variable.value,
       isSensitive: variable.sensitive,


### PR DESCRIPTION
### Issue & Steps to Reproduce
`configurationChanges` attribute in deploy request was missing the `scope` field.

### Solution
Added `scope` field as `DEPLOYMENT`

