### PR TITLE
Fix: initial deployment wrong arguments

### DIFF
--- a/node/src/lib/deploy-utils.js
+++ b/node/src/lib/deploy-utils.js
@@ -12,7 +12,6 @@ const {
   TARGETS,
   ENVIRONMENT_NAME,
   WORKSPACE_NAME,
-  ORGANIZATION_ID,
   PROJECT_ID
 } = options;
 
@@ -41,9 +40,7 @@ class DeployUtils {
     const payload = removeEmptyValuesFromObj({
       name: options[ENVIRONMENT_NAME],
       workspaceName: options[WORKSPACE_NAME],
-      organizationId: options[ORGANIZATION_ID],
       projectId: options[PROJECT_ID],
-      lifespanEndAt: null,
       deployRequest: {
         blueprintId: options[BLUEPRINT_ID],
         blueprintRevision: options[REVISION]

--- a/node/tests/lib/deploy-utils.spec.js
+++ b/node/tests/lib/deploy-utils.spec.js
@@ -10,7 +10,7 @@ jest.mock('../../src/lib/api-client', () =>
   }))
 );
 
-const { BLUEPRINT_ID, REVISION, REQUIRES_APPROVAL, TARGETS, ENVIRONMENT_NAME, ORGANIZATION_ID, PROJECT_ID } = options;
+const { BLUEPRINT_ID, REVISION, REQUIRES_APPROVAL, TARGETS, ENVIRONMENT_NAME, PROJECT_ID } = options;
 
 const mockDeploymentId = 'deployment0';
 const mockDeployment = { id: mockDeploymentId };
@@ -146,7 +146,6 @@ describe('deploy utils', () => {
         [REVISION]: 'rev0',
         [BLUEPRINT_ID]: 'blueprint0',
         [ENVIRONMENT_NAME]: 'foo',
-        [ORGANIZATION_ID]: 'org0',
         [PROJECT_ID]: 'proj0'
       };
 
@@ -154,9 +153,7 @@ describe('deploy utils', () => {
 
       const expectedPayload = {
         name: mockOptions[ENVIRONMENT_NAME],
-        organizationId: mockOptions[ORGANIZATION_ID],
         projectId: mockOptions[PROJECT_ID],
-        lifespanEndAt: null,
         deployRequest: {
           blueprintId: mockOptions[BLUEPRINT_ID],
           blueprintRevision: mockOptions[REVISION]


### PR DESCRIPTION
### Issue & Steps to Reproduce
After adding API requets validation to env0 backend, the initial deployment request started failing due to unnecessary `organizationId` and `lifespanEndAt` parameters in body.

### Solution
Remove `organizationId` and `lifespanEndAt` params from request body.

