### PR TITLE
Fix: Persist configuration only in env0 configure

### DIFF
--- a/node/src/commands/run-command.js
+++ b/node/src/commands/run-command.js
@@ -37,8 +37,6 @@ const runCommand = async (command, options, environmentVariables) => {
   assertRequiredOptions(options);
   assertRequiresApprovalOption(options[REQUIRES_APPROVAL]);
 
-  configManager.write(options);
-
   logger.setSecrets(options);
 
   logger.info(`Running ${command} with the following arguments:`);

--- a/node/tests/commands/run-command.spec.js
+++ b/node/tests/commands/run-command.spec.js
@@ -29,12 +29,19 @@ describe('run command', () => {
     jest.spyOn(configManager, 'read').mockReturnValue(mockRequiredOptions);
   });
 
-  it('should read and write persistent options', async () => {
-    await runCommand('deploy', mockRequiredOptions);
+  describe('configuration', () => {
+    beforeEach(async () => {
+      await runCommand('deploy', mockRequiredOptions);
+    })
 
-    expect(configManager.read).toBeCalled();
-    expect(configManager.write).toBeCalled();
-  });
+    it('should read configuration and merge with input options', async () => {
+      expect(configManager.read).toBeCalledWith(mockRequiredOptions);
+    });
+
+    it('should not overwrite configuration', async () => {
+      expect(configManager.write).not.toBeCalled();
+    })
+  })
 
   describe('when there are missing required options', () => {
     it('should fail with proper error message', async () => {


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
Right now, we persist the flags we get in actions like deploy/destroy in our config file. We want to stop doing that
### Solution
Stop doing that

