### PR TITLE
Fix: support requires approval parameter in create api

### DIFF
--- a/node/src/lib/deploy-utils.js
+++ b/node/src/lib/deploy-utils.js
@@ -45,7 +45,8 @@ class DeployUtils {
         blueprintId: options[BLUEPRINT_ID],
         blueprintRevision: options[REVISION]
       },
-      configurationChanges
+      configurationChanges,
+      requiresApproval: convertStringToBoolean(options[REQUIRES_APPROVAL])
     });
 
     return await apiClient.callApi('post', 'environments', { data: payload }); // returns the newly created environment with updated deployment log

--- a/node/tests/lib/deploy-utils.spec.js
+++ b/node/tests/lib/deploy-utils.spec.js
@@ -146,7 +146,8 @@ describe('deploy utils', () => {
         [REVISION]: 'rev0',
         [BLUEPRINT_ID]: 'blueprint0',
         [ENVIRONMENT_NAME]: 'foo',
-        [PROJECT_ID]: 'proj0'
+        [PROJECT_ID]: 'proj0',
+        [REQUIRES_APPROVAL]: 'true'
       };
 
       const configurationChanges = { config1: 'foo', config2: 'bar' };
@@ -158,7 +159,8 @@ describe('deploy utils', () => {
           blueprintId: mockOptions[BLUEPRINT_ID],
           blueprintRevision: mockOptions[REVISION]
         },
-        configurationChanges
+        configurationChanges,
+        requiresApproval: true
       };
 
       await deployUtils.createAndDeployEnvironment(mockOptions, configurationChanges);


### PR DESCRIPTION
### Issue & Steps to Reproduce
Create API (aka first deploy) doesn't support the `requiresApproval` parameter.

### Solution
Add it 😺 

