### PR TITLE
Fix: Most of the commands fail do to arguments not being resolved correctly

### DIFF
--- a/node/src/main.js
+++ b/node/src/main.js
@@ -56,7 +56,7 @@ const run = async () => {
 
     assertCommandExists(command);
 
-    const currentCommandOptions = getCommandOptions(command);
+    const currentCommandOptions = getCommandOptions(command, argv);
 
     const environmentVariables = getEnvironmentVariablesOptions(
       currentCommandOptions[ENVIRONMENT_VARIABLES],

--- a/node/tests/commands/run-command.spec.js
+++ b/node/tests/commands/run-command.spec.js
@@ -32,7 +32,7 @@ describe('run command', () => {
   describe('configuration', () => {
     beforeEach(async () => {
       await runCommand('deploy', mockRequiredOptions);
-    })
+    });
 
     it('should read configuration and merge with input options', async () => {
       expect(configManager.read).toBeCalledWith(mockRequiredOptions);
@@ -40,8 +40,8 @@ describe('run command', () => {
 
     it('should not overwrite configuration', async () => {
       expect(configManager.write).not.toBeCalled();
-    })
-  })
+    });
+  });
 
   describe('when there are missing required options', () => {
     it('should fail with proper error message', async () => {

--- a/node/tests/main.spec.js
+++ b/node/tests/main.spec.js
@@ -81,13 +81,6 @@ describe('main', () => {
         it('should not call run deployment', () => {
           expect(runCommand).not.toBeCalled();
         });
-
-        it('should call commandLineArgs once, to get the command', () => {
-          expect(commandLineArgs).toHaveBeenCalledTimes(1);
-          expect(commandLineArgs).toHaveBeenCalledWith([{ name: 'command', defaultOption: true }], {
-            stopAtFirstUnknown: true
-          });
-        });
       });
     });
 

--- a/node/tests/main.spec.js
+++ b/node/tests/main.spec.js
@@ -1,6 +1,7 @@
 const runCommand = require('../src/commands/run-command');
 const run = require('../src/main');
 const commandLineArgs = require('command-line-args');
+const { commands } = require('../src/config/commands');
 const { version } = require('../package.json');
 const help = require('../src/commands/help');
 const configure = require('../src/commands/configure');
@@ -80,6 +81,13 @@ describe('main', () => {
         it('should not call run deployment', () => {
           expect(runCommand).not.toBeCalled();
         });
+
+        it('should call commandLineArgs once, to get the command', () => {
+          expect(commandLineArgs).toHaveBeenCalledTimes(1);
+          expect(commandLineArgs).toHaveBeenCalledWith([{ name: 'command', defaultOption: true }], {
+            stopAtFirstUnknown: true
+          });
+        });
       });
     });
 
@@ -112,6 +120,30 @@ describe('main', () => {
 
       it('should not call run deployment', () => {
         expect(runCommand).not.toBeCalled();
+      });
+    });
+
+    describe('commands with flags', () => {
+      describe.each`
+        command
+        ${'deploy'}
+        ${'destroy'}
+        ${'cancel'}
+        ${'approve'}
+        ${'configure'}
+      `('on $command', ({ command }) => {
+        const args = getMockOptions(command);
+        const rawArgs = ['raw', 'args'];
+
+        beforeEach(async () => {
+          await mockOptionsAndRun({ command, rawArgs, args });
+        });
+
+        const expectedCommandOptions = commands[command].options;
+
+        it('should call commandLineArgs to get arguments from the command options, using the rawArgs', () => {
+          expect(commandLineArgs).toHaveBeenCalledWith(expectedCommandOptions, { argv: rawArgs });
+        });
       });
     });
 


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
`deploy`,`destroy`,`cancel` and `approve` all fail because the flags were not sent to `commandLineArgs` when resolving the arguments
### Solution
Send the args

