### PR TITLE
Fix: log errors properly based on axios response 

### DIFF
--- a/node/src/main.js
+++ b/node/src/main.js
@@ -21,6 +21,21 @@ const assertCommandExists = command => {
   }
 };
 
+const logErrors = (command, error) => {
+  commands[command] && logger.error(`Command ${command} has failed.`);
+  let { message } = error;
+
+  if (error.response && error.response.data) {
+    message += ':\n';
+
+    const { data } = error.response;
+    if (data.message) message += `${data.message}\n`;
+    if (Array.isArray(data)) data.forEach(line => (message += `${line}\n`));
+  }
+
+  logger.error(message);
+};
+
 const isInternalCommand = async (command, args) => {
   let isInternalCmd = false;
 
@@ -65,13 +80,7 @@ const run = async () => {
 
     await runCommand(command, currentCommandOptions, environmentVariables);
   } catch (error) {
-    commands[command] && logger.error(`Command ${command} has failed. Error:`);
-    let { message } = error;
-    if (error.response && error.response.data && error.response.data.message) {
-      message += `: ${error.response.data.message}`;
-    }
-
-    logger.error(message);
+    logErrors(command, error);
     process.exit(1);
   }
 };

--- a/node/tests/main.spec.js
+++ b/node/tests/main.spec.js
@@ -63,6 +63,23 @@ describe('main', () => {
   });
 
   describe('when command exists', () => {
+    describe.each`
+      responseData               | expected
+      ${{ message: 'test' }}     | ${'test'}
+      ${['one', 'two', 'three']} | ${'one\ntwo\nthree'}
+    `('when command fails with $responseData', ({ responseData, expected }) => {
+      beforeEach(async () => {
+        runCommand.mockRejectedValue({ response: { data: responseData }, message: 'testing errors' });
+
+        const command = 'deploy';
+        await mockOptionsAndRun({ command, rawArgs: [], args: getMockOptions(command) });
+      });
+
+      it('should log errors', () => {
+        expect(logger.error).toBeCalledWith(expect.stringContaining(expected));
+      });
+    });
+
     describe('help', () => {
       describe.each`
         command   | rawArgs


### PR DESCRIPTION
### Issue & Steps to Reproduce
Our BE validation process returns axios `response.data` in the shape of an array of strings instead of the usual `{ message: string }` object.

### Solution
Parse also the array's messages, if exists.

