### PR TITLE
Fix: show better error messages #2

### DIFF
--- a/node/src/main.js
+++ b/node/src/main.js
@@ -1,4 +1,5 @@
 const commandLineArgs = require('command-line-args');
+const _ = require('lodash');
 const runCommand = require('./commands/run-command');
 const updateNotifier = require('update-notifier');
 const pkg = require('../package.json');
@@ -29,8 +30,9 @@ const logErrors = (command, error) => {
     message += ':\n';
 
     const { data } = error.response;
-    if (data.message) message += `${data.message}\n`;
-    if (Array.isArray(data)) data.forEach(line => (message += `${line}\n`));
+    if (_.isArray(data)) data.forEach(line => (message += `${line}\n`));
+    else if (_.isString(data)) message += `${data}\n`;
+    else if (data.message) message += `${data.message}\n`;
   }
 
   logger.error(message);

--- a/node/src/main.js
+++ b/node/src/main.js
@@ -21,6 +21,21 @@ const assertCommandExists = command => {
   }
 };
 
+const logErrors = (command, error) => {
+  commands[command] && logger.error(`Command ${command} has failed.`);
+  let { message } = error;
+
+  if (error.response && error.response.data) {
+    message += ':\n';
+
+    const { data } = error.response;
+    if (data.message) message += `${data.message}\n`;
+    if (Array.isArray(data)) data.forEach(line => (message += `${line}\n`));
+  }
+
+  logger.error(message);
+};
+
 const isInternalCommand = async (command, args) => {
   let isInternalCmd = false;
 
@@ -65,13 +80,7 @@ const run = async () => {
 
     await runCommand(command, currentCommandOptions, environmentVariables);
   } catch (error) {
-    commands[command] && logger.error(`Command ${command} has failed. Error:`);
-    let { message } = error;
-    if (error.response && error.response.data && error.response.data.message) {
-      message += `: ${error.response.data.message}`;
-    }
-
-    logger.error(message);
+    logErrors(command, error);
     process.exit(1);
   }
 };

--- a/node/tests/main.spec.js
+++ b/node/tests/main.spec.js
@@ -63,6 +63,23 @@ describe('main', () => {
   });
 
   describe('when command exists', () => {
+    describe.each`
+      responseData               | expected
+      ${{ message: 'test' }}     | ${'test'}
+      ${['one', 'two', 'three']} | ${'one\ntwo\nthree'}
+    `('when command fails with $responseData', ({ responseData, expected }) => {
+      beforeEach(async () => {
+        runCommand.mockRejectedValue({ response: { data: responseData }, message: 'testing errors' });
+
+        const command = 'deploy';
+        await mockOptionsAndRun({ command, rawArgs: [], args: getMockOptions(command) });
+      });
+
+      it('should log errors', () => {
+        expect(logger.error).toBeCalledWith(expect.stringContaining(expected));
+      });
+    });
+
     describe('help', () => {
       describe.each`
         command   | rawArgs

--- a/node/tests/main.spec.js
+++ b/node/tests/main.spec.js
@@ -65,8 +65,9 @@ describe('main', () => {
   describe('when command exists', () => {
     describe.each`
       responseData               | expected
-      ${{ message: 'test' }}     | ${'test'}
+      ${{ message: 'test' }}     | ${'test\n'}
       ${['one', 'two', 'three']} | ${'one\ntwo\nthree'}
+      ${'one'}                   | ${'one\n'}
     `('when command fails with $responseData', ({ responseData, expected }) => {
       beforeEach(async () => {
         runCommand.mockRejectedValue({ response: { data: responseData }, message: 'testing errors' });


### PR DESCRIPTION
### Issue & Steps to Reproduce
After #70 was merged, it turns out there's also a case where `response.data` ia a string.

### Solution
Treat that case.

