### PR TITLE
Chore: increase find step log api calls interval

### DIFF
--- a/node/src/lib/deploy-utils.js
+++ b/node/src/lib/deploy-utils.js
@@ -82,6 +82,7 @@ class DeployUtils {
   }
 
   async writeDeploymentStepLog(deploymentLogId, stepName) {
+    const pollInProgressStepLogInterval = 10000; // 10 seconds
     let shouldPoll = false;
     let startTime = undefined;
 
@@ -99,7 +100,7 @@ class DeployUtils {
       events.forEach(event => logger.info(event.message));
 
       if (nextStartTime) startTime = nextStartTime;
-      if (stepInProgress) await apiClient.sleep(10000);
+      if (stepInProgress) await apiClient.sleep(pollInProgressStepLogInterval);
 
       shouldPoll = hasMoreLogs || stepInProgress;
     } while (shouldPoll);
@@ -126,7 +127,8 @@ class DeployUtils {
   }
 
   async pollDeploymentStatus(deployment, shouldProcessDeploymentSteps = true) {
-    const MAX_TIME_IN_SECONDS = 10800; // 3 hours
+    const maxTimeInSeconds = 10800; // 3 hours
+    const pollStepLogsInterval = 30000; // 30 seconds
     const start = Date.now();
     const stepsAlreadyLogged = [];
     let previousStatus;
@@ -158,10 +160,10 @@ class DeployUtils {
       }
 
       const elapsedTimeInSeconds = (Date.now() - start) / 1000;
-      if (elapsedTimeInSeconds > MAX_TIME_IN_SECONDS) throw new Error('Polling deployment timed out');
+      if (elapsedTimeInSeconds > maxTimeInSeconds) throw new Error('Polling deployment timed out');
 
       previousStatus = status;
-      await apiClient.sleep(30000);
+      await apiClient.sleep(pollStepLogsInterval);
     }
   }
 

--- a/node/src/lib/deploy-utils.js
+++ b/node/src/lib/deploy-utils.js
@@ -99,7 +99,7 @@ class DeployUtils {
       events.forEach(event => logger.info(event.message));
 
       if (nextStartTime) startTime = nextStartTime;
-      if (stepInProgress) await apiClient.sleep(1000);
+      if (stepInProgress) await apiClient.sleep(10000);
 
       shouldPoll = hasMoreLogs || stepInProgress;
     } while (shouldPoll);
@@ -161,7 +161,7 @@ class DeployUtils {
       if (elapsedTimeInSeconds > MAX_TIME_IN_SECONDS) throw new Error('Polling deployment timed out');
 
       previousStatus = status;
-      await apiClient.sleep(5000);
+      await apiClient.sleep(30000);
     }
   }
 


### PR DESCRIPTION
### Issue & Steps to Reproduce
Due to some caching issues with API Gateway, we reach limits from our 3rd-party authorization provider when using API keys on getting a step log's output. 

### Solution
Temporary increase the find-step-logs API call interval.

