### PR TITLE
Fix: Allow same workspace name on redeploy

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@env0/cli",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "env0 CLI",
   "repository": {
     "type": "git",

--- a/node/tests/commands/deploy.spec.js
+++ b/node/tests/commands/deploy.spec.js
@@ -96,12 +96,24 @@ describe('deploy', () => {
       expect(mockPollDeploymentStatus).toBeCalledWith(mockDeployment);
     });
 
-    it('should not allow to redeploy with workspace name set', async () => {
+    it('should not allow to redeploy with a different workspace name set', async () => {
       mockGetEnvironment.mockResolvedValue(mockEnvironment);
 
       await expect(deploy({ [WORKSPACE_NAME]: 'workspace0' }, environmentVariables)).rejects.toThrowError(
-        'You may only set Terraform Workspace on the first deployment of an environment'
+        'You cannot change a workspace name once an environment has been deployed'
       );
+    });
+
+    it('should allow to redeploy with the same workspace name', async () => {
+      let existingEnvironmentWithWorkspace = { ...mockEnvironment, [WORKSPACE_NAME]: 'workspace0' };
+      mockGetEnvironment.mockResolvedValue(existingEnvironmentWithWorkspace);
+
+      await deploy(mockOptionsWithRequired, environmentVariables)
+
+      const expectedOptions = { ...mockOptionsWithRequired }
+      delete expectedOptions[WORKSPACE_NAME]
+
+      expect(mockDeployEnvironment).toBeCalledWith(existingEnvironmentWithWorkspace, expectedOptions, expectedConfigurationChanges);
     });
   });
 


### PR DESCRIPTION
### Issue
Redeploying with `-w` for workspace name assumes one's trying to **change** the workspace name of existing env.  

### Solution
Instead - we should check that it has been changed and only then throw an error - otherwise - it should be allowed.

