### PR TITLE
Chore: use name query param when getting environments

### DIFF
--- a/node/src/lib/deploy-utils.js
+++ b/node/src/lib/deploy-utils.js
@@ -2,6 +2,7 @@ const Env0ApiClient = require('./api-client');
 const logger = require('./logger');
 const { options } = require('../config/constants');
 const { convertStringToBoolean, removeEmptyValuesFromObj } = require('./general-utils');
+const { isEmpty } = require('lodash');
 
 const {
   API_KEY,
@@ -25,7 +26,7 @@ class DeployUtils {
   async getEnvironment(environmentName, projectId) {
     const environments = await apiClient.callApi('get', `environments?projectId=${projectId}&name=${environmentName}`);
 
-    return (environments && environments[0]) || undefined;
+    return isEmpty(environments) ? undefined : environments[0];
   }
 
   async getDeployment(deploymentLogId) {

--- a/node/src/lib/deploy-utils.js
+++ b/node/src/lib/deploy-utils.js
@@ -23,9 +23,9 @@ class DeployUtils {
   }
 
   async getEnvironment(environmentName, projectId) {
-    const environments = await apiClient.callApi('get', `environments?projectId=${projectId}`);
+    const environments = await apiClient.callApi('get', `environments?projectId=${projectId}&name=${environmentName}`);
 
-    return environments.find(env => env.name === environmentName);
+    return (environments && environments[0]) || undefined;
   }
 
   async getDeployment(deploymentLogId) {

--- a/node/tests/lib/deploy-utils.spec.js
+++ b/node/tests/lib/deploy-utils.spec.js
@@ -222,4 +222,30 @@ describe('deploy utils', () => {
       expect(mockCallApi).toBeCalledWith('put', `environments/deployments/${mockDeploymentId}/cancel`);
     });
   });
+
+  describe('get environments', () => {
+    const environmentName = 'env0';
+    const projectId = 'projectX';
+    const environments = ['id1', 'id2', 'id3'].map(id => ({ id }));
+    let response;
+
+    describe.each`
+      when     | apiResponse     | expectedReturnValue
+      ${''}    | ${environments} | ${environments[0]}
+      ${'NOT'} | ${[]}           | ${undefined}
+    `('when environment was $when found', ({ apiResponse, expectedReturnValue }) => {
+      beforeEach(async () => {
+        mockCallApi.mockReturnValue(apiResponse);
+        response = await deployUtils.getEnvironment(environmentName, projectId);
+      });
+
+      it('should call api', async () => {
+        expect(mockCallApi).toBeCalledWith('get', `environments?projectId=${projectId}&name=${environmentName}`);
+      });
+
+      it(`should return ${expectedReturnValue}`, () => {
+        expect(response).toEqual(expectedReturnValue);
+      });
+    });
+  });
 });


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
We're getting `502` from env0 BE when trying to get all environments for a project. 

### Solution
Use the `name` query param for the GET `/environments` API so filtering would be done by BE and not on client

