### PR TITLE
Fix: Don't send scope variable

### DIFF
--- a/node/src/commands/deploy.js
+++ b/node/src/commands/deploy.js
@@ -15,7 +15,6 @@ const assertNoWorkspaceNameChanges = (options, environment) => {
 
 const getConfigurationChanges = environmentVariables =>
   (environmentVariables || []).map(variable => ({
-    scope: 'DEPLOYMENT',
     isSensitive: variable.sensitive,
     name: variable.name,
     value: variable.value,

--- a/node/tests/commands/deploy.spec.js
+++ b/node/tests/commands/deploy.spec.js
@@ -72,7 +72,6 @@ describe('deploy', () => {
     ];
 
     const expectedConfigurationChanges = environmentVariables.map(variable => ({
-      scope: 'DEPLOYMENT',
       name: variable.name,
       value: variable.value,
       isSensitive: variable.sensitive,


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
The CLI sends the scope variable to the api.

### Solution
Remove the scope sent by the CLI.
