### PR TITLE
chore: add publish section in README

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -141,3 +141,12 @@ You can compile and run the CLI from source by cloning the repo from Github and 
 yarn install
 yarn link # link your local copy of the CLI to your terminal path
 ```
+
+
+## Publishing
+```bash
+# we publish it to the public npm (consider cleaning your global `~/.npmrc` file)
+# make sure your user have permissions under env0's npm organization
+npm login
+npm publish --access public
+```

--- a/node/package.json
+++ b/node/package.json
@@ -17,7 +17,6 @@
   "scripts": {
     "test": "jest",
     "lint": "eslint .",
-    "publish": "npm login && npm publish --access public",
     "postinstall": "npm shrinkwrap"
   },
   "license": "MIT",


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
`npm publish` call isteslf

### Solution
add publish section in README
remove publish script because it's causing a publishing loop

