### PR TITLE
Obtain JWT on client init

### DIFF
--- a/node/src/lib/api-client.js
+++ b/node/src/lib/api-client.js
@@ -3,13 +3,19 @@ const { version } = require('../../package.json');
 
 class Env0ApiClient {
   async init(apiKey, apiSecret) {
-    this.apiClient = axios.create({
-      baseURL: process.env.ENV0_API_URL || 'https://api.env0.com',
-      auth: {
+    const baseURL = process.env.ENV0_API_URL || 'https://api.env0.com';
+
+    const {data: jwt} = await axios.get('auth/jwt?encoded=true', {
+      baseURL, method: 'GET', auth: {
         username: apiKey,
         password: apiSecret
-      },
+      }
+    });
+
+    this.apiClient = axios.create({
+      baseURL: process.env.ENV0_API_URL || 'https://api.env0.com',
       headers: {
+        Authorization: `Bearer ${jwt}`,
         Accept: 'application/json',
         'Content-Type': 'application/json',
         'User-Agent': `env0-node-cli-${version}`

--- a/node/src/lib/api-client.js
+++ b/node/src/lib/api-client.js
@@ -5,7 +5,7 @@ class Env0ApiClient {
   async init(apiKey, apiSecret) {
     const baseURL = process.env.ENV0_API_URL || 'https://api.env0.com';
 
-    const {data: jwt} = await axios.get('auth/token?encoded=true', {
+    const { data: jwt } = await axios.get('auth/token?encoded=true', {
       baseURL,
       method: 'GET',
       auth: {

--- a/node/src/lib/api-client.js
+++ b/node/src/lib/api-client.js
@@ -5,7 +5,7 @@ class Env0ApiClient {
   async init(apiKey, apiSecret) {
     const baseURL = process.env.ENV0_API_URL || 'https://api.env0.com';
 
-    const {data: jwt} = await axios.get('auth/jwt?encoded=true', {
+    const {data: jwt} = await axios.get('auth/token?encoded=true', {
       baseURL,
       method: 'GET',
       auth: {

--- a/node/src/lib/api-client.js
+++ b/node/src/lib/api-client.js
@@ -6,7 +6,9 @@ class Env0ApiClient {
     const baseURL = process.env.ENV0_API_URL || 'https://api.env0.com';
 
     const {data: jwt} = await axios.get('auth/jwt?encoded=true', {
-      baseURL, method: 'GET', auth: {
+      baseURL,
+      method: 'GET',
+      auth: {
         username: apiKey,
         password: apiSecret
       }

--- a/node/tests/lib/api-client.spec.js
+++ b/node/tests/lib/api-client.spec.js
@@ -7,12 +7,19 @@ const mockKey = 'key0';
 const mockSecret = 'secret0';
 
 describe('api-client', () => {
+  const jwt = 'iamjwt';
+
   beforeEach(() => {
+    (axios.get).mockResolvedValue({ data: jwt });
     new ApiClient().init(mockKey, mockSecret);
   });
 
-  it('should set authorization header', () => {
-    expect(axios.create).toBeCalledWith(expect.objectContaining({ auth: { username: mockKey, password: mockSecret } }));
+  it('should obtain a jwt', () => {
+    expect(axios.get).toBeCalledWith('auth/token?encoded=true', expect.objectContaining({ auth: { username: mockKey, password: mockSecret } }));
+  });
+
+  it('should set authorization to jwt', () => {
+    expect(axios.create).toBeCalledWith(expect.objectContaining({ headers: expect.objectContaining({ Authorization: `Bearer ${jwt}` }) }));
   });
 
   it('should set user agent header', () => {


### PR DESCRIPTION
### Issue
We're seeing an elevated rate of throttling errors as we do not benefit from cache when using user/password.  

### Solution
Use user/password once to obtain JWT and use that on following API calls.

.