### PR TITLE
Revert: Obtain JWT on client init

### DIFF
--- a/node/npm-shrinkwrap.json
+++ b/node/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@env0/cli",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@env0/cli",
-      "version": "1.0.19",
+      "version": "1.0.20",
       "license": "MIT",
       "dependencies": {
         "axios": "0.21.2",

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@env0/cli",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "env0 CLI",
   "repository": {
     "type": "git",

--- a/node/src/lib/api-client.js
+++ b/node/src/lib/api-client.js
@@ -3,21 +3,13 @@ const { version } = require('../../package.json');
 
 class Env0ApiClient {
   async init(apiKey, apiSecret) {
-    const baseURL = process.env.ENV0_API_URL || 'https://api.env0.com';
-
-    const { data: jwt } = await axios.get('auth/token?encoded=true', {
-      baseURL,
-      method: 'GET',
+    this.apiClient = axios.create({
+      baseURL: process.env.ENV0_API_URL || 'https://api.env0.com',
       auth: {
         username: apiKey,
         password: apiSecret
-      }
-    });
-
-    this.apiClient = axios.create({
-      baseURL: process.env.ENV0_API_URL || 'https://api.env0.com',
+      },
       headers: {
-        Authorization: `Bearer ${jwt}`,
         Accept: 'application/json',
         'Content-Type': 'application/json',
         'User-Agent': `env0-node-cli-${version}`

--- a/node/tests/lib/api-client.spec.js
+++ b/node/tests/lib/api-client.spec.js
@@ -7,19 +7,12 @@ const mockKey = 'key0';
 const mockSecret = 'secret0';
 
 describe('api-client', () => {
-  const jwt = 'iamjwt';
-
   beforeEach(() => {
-    (axios.get).mockResolvedValue({ data: jwt });
     new ApiClient().init(mockKey, mockSecret);
   });
 
-  it('should obtain a jwt', () => {
-    expect(axios.get).toBeCalledWith('auth/token?encoded=true', expect.objectContaining({ auth: { username: mockKey, password: mockSecret } }));
-  });
-
-  it('should set authorization to jwt', () => {
-    expect(axios.create).toBeCalledWith(expect.objectContaining({ headers: expect.objectContaining({ Authorization: `Bearer ${jwt}` }) }));
+  it('should set authorization header', () => {
+    expect(axios.create).toBeCalledWith(expect.objectContaining({ auth: { username: mockKey, password: mockSecret } }));
   });
 
   it('should set user agent header', () => {


### PR DESCRIPTION
Reverts env0/env0-client-integrations#112  

We've made it so that the env0 will properly use a short-term cache for user/password auth, so no need for each client to obtain a JWT first.