### PR TITLE
Chore: use node 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Use Node.js 10.x
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
-        node-version: 10.x
+        node-version: 14.x
     - name: install dependencies
       working-directory: ${{ matrix.package }}
       run: yarn

--- a/node/npm-shrinkwrap.json
+++ b/node/npm-shrinkwrap.json
@@ -31,7 +31,7 @@
         "prettier": "2.0.5"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=14"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/node/package.json
+++ b/node/package.json
@@ -8,7 +8,7 @@
     "directory": "node"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=14"
   },
   "bugs": {
     "url": "https://github.com/env0/env0-client-integrations/issues"


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
https://github.com/env0/env0-client-integrations/pull/115 fails b/c the new dependency version needs at least node 14.

[node 10 is EOL](https://github.com/nodejs/release#end-of-life-releases) 

### Solution
use node 14 - the oldest maintained LTS release

