### PR TITLE
Prepare release v1.0.21

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,3 +1,4 @@
 feature: ['feature-*', 'feat-*']
 fix: fix-*
 chore: chore-*
+prepare-release: prepare-release-*

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - prepare-release

--- a/node/npm-shrinkwrap.json
+++ b/node/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "@env0/cli",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@env0/cli",
-      "version": "1.0.20",
+      "version": "1.0.21",
       "license": "MIT",
       "dependencies": {
         "axios": "0.21.2",

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@env0/cli",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "env0 CLI",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Issue & Steps to Reproduce / Feature Request
release version with security updates

### Solution
- bump version
- auto label `prepare-release-*` branches
- exclude PRs with `prepare-release` label from release notes

