### PR TITLE
Feat: Add checkoutUpdatedCode parameter to destroy command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Use Node.js 14.x
+    - name: Use Node.js
       uses: actions/setup-node@v1
       with:
-        node-version: 14.x
+        node-version: 24.x
     - name: install dependencies
       working-directory: ${{ matrix.package }}
       run: yarn

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -15,7 +15,7 @@ jobs:
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v2
         with:
-          node-version: '16.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm publish --access public

--- a/node/npm-shrinkwrap.json
+++ b/node/npm-shrinkwrap.json
@@ -74,6 +74,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.5.tgz",
       "integrity": "sha512-UdOWmk4pNWTm/4DlPUl/Pt4Gz4rcEMb7CY0Y3eJl5Yz1vI8ZJGmHWaVE55LoxRjdpx0z259GE9U5STA9atUinQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
@@ -1734,6 +1735,7 @@
           "url": "https://tidelift.com/funding/github/npm/browserslist"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001400",
         "electron-to-chromium": "^1.4.251",
@@ -7687,6 +7689,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.5.tgz",
       "integrity": "sha512-UdOWmk4pNWTm/4DlPUl/Pt4Gz4rcEMb7CY0Y3eJl5Yz1vI8ZJGmHWaVE55LoxRjdpx0z259GE9U5STA9atUinQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.1.0",
         "@babel/code-frame": "^7.18.6",
@@ -9013,6 +9016,7 @@
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
       "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001400",
         "electron-to-chromium": "^1.4.251",

--- a/node/src/commands/destroy.js
+++ b/node/src/commands/destroy.js
@@ -3,7 +3,7 @@ const { options } = require('../config/constants');
 const _ = require('lodash');
 const { convertStringToBoolean, removeEmptyValuesFromObj } = require('../lib/general-utils');
 
-const { ENVIRONMENT_NAME, REQUIRES_APPROVAL, SKIP_STATE_REFRESH } = options;
+const { ENVIRONMENT_NAME, REQUIRES_APPROVAL, SKIP_STATE_REFRESH, CHECKOUT_UPDATED_CODE } = options;
 
 const assertEnvironmentExists = environment => {
   if (!environment) {
@@ -26,7 +26,8 @@ const destroy = async options => {
   }
 
   const params = removeEmptyValuesFromObj({
-    [SKIP_STATE_REFRESH]: options[SKIP_STATE_REFRESH]
+    [SKIP_STATE_REFRESH]: options[SKIP_STATE_REFRESH],
+    [CHECKOUT_UPDATED_CODE]: options[CHECKOUT_UPDATED_CODE]
   });
   const deployment = await deployUtils.destroyEnvironment(environment, params);
 

--- a/node/src/config/arguments.js
+++ b/node/src/config/arguments.js
@@ -15,7 +15,8 @@ const {
   REVISION,
   SKIP_STATE_REFRESH,
   REQUIRES_APPROVAL,
-  TARGETS
+  TARGETS,
+  CHECKOUT_UPDATED_CODE
 } = options;
 
 const argumentsMap = {
@@ -134,6 +135,12 @@ const argumentsMap = {
     type: String,
     group: ['destroy'],
     description: 'Disable automatic state refresh on plan destroy phase'
+  },
+  [CHECKOUT_UPDATED_CODE]: {
+    name: CHECKOUT_UPDATED_CODE,
+    type: String,
+    group: ['destroy'],
+    description: 'Checkout updated code before destroying the environment'
   },
   [TARGETS]: {
     name: TARGETS,

--- a/node/src/config/commands.js
+++ b/node/src/config/commands.js
@@ -1,7 +1,7 @@
 const { argumentsMap, allArguments, baseArguments } = require('./arguments');
 const { options } = require('./constants');
 
-const { API_KEY, API_SECRET, ORGANIZATION_ID, PROJECT_ID, ENVIRONMENT_NAME, BLUEPRINT_ID, SKIP_STATE_REFRESH, REQUIRES_APPROVAL } = options;
+const { API_KEY, API_SECRET, ORGANIZATION_ID, PROJECT_ID, ENVIRONMENT_NAME, BLUEPRINT_ID, SKIP_STATE_REFRESH, REQUIRES_APPROVAL, CHECKOUT_UPDATED_CODE } = options;
 
 const commands = {
   deploy: {
@@ -14,7 +14,7 @@ const commands = {
     ]
   },
   destroy: {
-    options: [...baseArguments, argumentsMap[REQUIRES_APPROVAL], argumentsMap[SKIP_STATE_REFRESH]],
+    options: [...baseArguments, argumentsMap[REQUIRES_APPROVAL], argumentsMap[SKIP_STATE_REFRESH], argumentsMap[CHECKOUT_UPDATED_CODE]],
     help: [
       {
         desc: 'Destroys an environment',

--- a/node/src/config/constants.js
+++ b/node/src/config/constants.js
@@ -13,7 +13,8 @@ const options = {
   REVISION: 'revision',
   SKIP_STATE_REFRESH: 'skipStateRefresh',
   REQUIRES_APPROVAL: 'requiresApproval',
-  TARGETS: 'targets'
+  TARGETS: 'targets',
+  CHECKOUT_UPDATED_CODE: 'checkoutUpdatedCode'
 };
 
 module.exports = {

--- a/node/tests/commands/destroy.spec.js
+++ b/node/tests/commands/destroy.spec.js
@@ -12,7 +12,7 @@ jest.mock('../../src/lib/deploy-utils');
 
 const mockDeployment = { id: 'id0' };
 
-const { ENVIRONMENT_NAME, REQUIRES_APPROVAL, SKIP_STATE_REFRESH } = options;
+const { ENVIRONMENT_NAME, REQUIRES_APPROVAL, SKIP_STATE_REFRESH, CHECKOUT_UPDATED_CODE } = options;
 
 describe('destroy', () => {
   beforeEach(() => {
@@ -56,6 +56,21 @@ describe('destroy', () => {
       ${{ [SKIP_STATE_REFRESH]: 'false' }}
       ${{}}
     `('should call destroyEnvironment with skipStateRefresh Option, options=$options', async ({ options }) => {
+      const mockEnvironment = { id: 'something', name: 'someone' };
+      mockGetEnvironment.mockResolvedValue(mockEnvironment);
+
+      await destroy(options);
+      expect(mockDestroyEnvironment).toBeCalledWith(expect.anything(), options);
+    });
+  });
+
+  describe('checkoutUpdatedCode argument', () => {
+    it.each`
+      options
+      ${{ [CHECKOUT_UPDATED_CODE]: 'true' }}
+      ${{ [CHECKOUT_UPDATED_CODE]: 'false' }}
+      ${{}}
+    `('should call destroyEnvironment with checkoutUpdatedCode Option, options=$options', async ({ options }) => {
       const mockEnvironment = { id: 'something', name: 'someone' };
       mockGetEnvironment.mockResolvedValue(mockEnvironment);
 


### PR DESCRIPTION
## Summary
- Add `checkoutUpdatedCode` parameter to the destroy command, following the same pattern as `skipStateRefresh`
- Update CI and publish workflows to use Node.js 24.x

## Test plan
- [x] Destroy command tests pass with new parameter (true, false, empty cases)
